### PR TITLE
fix: Better error handling

### DIFF
--- a/cmd/build.go
+++ b/cmd/build.go
@@ -97,7 +97,10 @@ func doBuild(opts buildOpts) (*dag.DAG, error) {
 		}
 	}
 
-	DAG.Rebuild(currentVersion, opts.forceRebuild, opts.runTests, opts.localOnly)
+	if err := DAG.Rebuild(currentVersion, opts.forceRebuild, opts.runTests, opts.localOnly); err != nil {
+		return nil, err
+	}
+
 	if opts.retagLatest {
 		logrus.Info("--retag-latest is set to true, latest tag will now use current image versions")
 		if err := DAG.RetagLatest(currentVersion); err != nil {


### PR DESCRIPTION
Before these changes, when a child image failed, dib would exit silently with status code 0