### PR TITLE
fix: `Retag` when local-only is set, should pull and tag the docker image

### DIFF
--- a/dag/dag.go
+++ b/dag/dag.go
@@ -16,6 +16,7 @@ type DAG struct {
 	Images      []*Image
 	Registry    types.DockerRegistry
 	Builder     types.ImageBuilder
+	Tagger      types.ImageTagger
 	TestRunners []types.TestRunner
 }
 
@@ -49,6 +50,7 @@ func (dag *DAG) GenerateDAG(buildPath string, registryPrefix string) {
 				Builder:     dag.Builder,
 				Registry:    dag.Registry,
 				TestRunners: dag.TestRunners,
+				Tagger:      dag.Tagger,
 			}
 
 			allParents[img.Name] = dockerfile.From

--- a/mock/registry.go
+++ b/mock/registry.go
@@ -9,8 +9,3 @@ func (r *Registry) RefExists(_ string) (bool, error) {
 	r.RefExistsCallCount++
 	return true, nil
 }
-
-func (r *Registry) Retag(_, _ string) error {
-	r.RetagCallCount++
-	return nil
-}

--- a/registry/registry.go
+++ b/registry/registry.go
@@ -26,11 +26,12 @@ func (r Registry) RefExists(imageRef string) (bool, error) {
 	return r.gcr.RefExists(imageRef)
 }
 
-// Retag creates a new tag from an existing one.
-func (r Registry) Retag(existingRef, toCreateRef string) error {
+// Tag creates a new tag from an existing one.
+func (r Registry) Tag(existingRef, toCreateRef string) error {
 	if r.dryRun {
 		logrus.Infof("[DRY-RUN] Retagging image from \"%s\" to \"%s\"", existingRef, toCreateRef)
 		return nil
 	}
+	logrus.Debugf("Retaging image on gcr, source %s, dest %s`", existingRef, toCreateRef)
 	return r.gcr.Retag(existingRef, toCreateRef)
 }

--- a/types/types.go
+++ b/types/types.go
@@ -25,6 +25,11 @@ type ImageBuilderOpts struct {
 	LocalOnly bool
 }
 
+// ImageTagger is an abstraction for tagging docker images.
+type ImageTagger interface {
+	Tag(from, to string) error
+}
+
 // TestRunner is an interface for dealing with docker tests, such as dgoss, trivy.
 type TestRunner interface {
 	RunTest(ref, path string) error
@@ -33,5 +38,4 @@ type TestRunner interface {
 // DockerRegistry is an interface for dealing with docker registries.
 type DockerRegistry interface {
 	RefExists(imageRef string) (bool, error)
-	Retag(existingRef, toCreateRef string) error
 }


### PR DESCRIPTION
Currently, local-only mode does not work if a subimage needs rebuild but not its parent. Dib doesn't find the version of the parent image.

This MR introduces a `retagLocal` action that will pull and tag locally the image when necessary