### PR TITLE
feat: Add junit dgoss reports & add human readable synthesis at build end

### DIFF
--- a/cmd/build.go
+++ b/cmd/build.go
@@ -25,7 +25,10 @@ import (
 	versn "github.com/radiofrance/dib/version"
 )
 
-const placeholderNonExistent = "non-existent"
+const (
+	placeholderNonExistent = "non-existent"
+	junitReportsDirectory  = "dist/testresults/goss"
+)
 
 func cmdBuild(cmd *cli.Cmd) {
 	var opts buildOpts
@@ -84,7 +87,7 @@ func doBuild(opts buildOpts) (*dag.DAG, error) {
 		Registry: gcrRegistry,
 		Builder:  dockerBuilderTagger,
 		TestRunners: []types.TestRunner{
-			dgoss.TestRunner{},
+			dgoss.NewTestRunner(junitReportsDirectory),
 		},
 	}
 
@@ -94,11 +97,10 @@ func doBuild(opts buildOpts) (*dag.DAG, error) {
 		DAG.Tagger = gcrRegistry
 	}
 
-	buildPath := path.Join(workingDir, opts.buildPath)
-	logrus.Infof("Building images in directory \"%s\"", buildPath)
+	logrus.Infof("Building images in directory \"%s\"", path.Join(workingDir, opts.buildPath))
 
 	logrus.Debug("Generate DAG")
-	DAG.GenerateDAG(buildPath, opts.registryURL)
+	DAG.GenerateDAG(workingDir, opts.buildPath, opts.registryURL)
 	logrus.Debug("Generate DAG -- Done")
 
 	dockerDir, err := findDockerRootDir(workingDir, opts.buildPath)

--- a/cmd/build.go
+++ b/cmd/build.go
@@ -38,7 +38,8 @@ func cmdBuild(cmd *cli.Cmd) {
 	cmd.BoolOptPtr(&opts.forceRebuild, "force-rebuild", false, "Forces rebuilding the entire image graph, without regarding if the target version already exists.") //nolint:lll
 	cmd.BoolOptPtr(&opts.disableGenerateGraph, "no-graph", false, "Disable generation of graph during the build process.")                                          //nolint:lll
 	cmd.BoolOptPtr(&opts.disableRunTests, "no-tests", false, "Disable execution of tests during the build process.")                                                //nolint:lll
-	cmd.BoolOptPtr(&opts.retagLatest, "retag-latest", false, "Should images be retagged with the 'latest' tag for this build")                                      //nolint:lll
+	cmd.BoolOptPtr(&opts.disableJunitReports, "no-junit", false, "Disable generation of junit reports when running tests")
+	cmd.BoolOptPtr(&opts.retagLatest, "retag-latest", false, "Should images be retagged with the 'latest' tag for this build") //nolint:lll
 	cmd.BoolOptPtr(&opts.localOnly, "local-only", false, "Build docker images locally, do not push on remote registry")
 
 	cmd.Action = func() {
@@ -87,7 +88,11 @@ func doBuild(opts buildOpts) (*dag.DAG, error) {
 		Registry: gcrRegistry,
 		Builder:  dockerBuilderTagger,
 		TestRunners: []types.TestRunner{
-			dgoss.NewTestRunner(junitReportsDirectory),
+			dgoss.NewTestRunner(dgoss.TestRunnerOptions{
+				ReportsDirectory: junitReportsDirectory,
+				WorkingDirectory: workingDir,
+				JUnitReports:     !opts.disableJunitReports,
+			}),
 		},
 	}
 

--- a/cmd/options.go
+++ b/cmd/options.go
@@ -10,15 +10,16 @@ const (
 )
 
 type buildOpts struct {
+	buildPath            string
+	disableGenerateGraph bool
+	disableJunitReports  bool
+	disableRunTests      bool
 	dryRun               bool
 	forceRebuild         bool
-	disableRunTests      bool
-	retagLatest          bool
-	disableGenerateGraph bool
 	localOnly            bool
-	buildPath            string
-	registryURL          string
 	referentialImage     string
+	registryURL          string
+	retagLatest          bool
 }
 
 func defaultOpts(opts *buildOpts, cmd *cli.Cmd) {

--- a/cmd/test.go
+++ b/cmd/test.go
@@ -11,6 +11,8 @@ func cmdTest(cmd *cli.Cmd) {
 	var opts buildOpts
 	defaultOpts(&opts, cmd)
 
+	cmd.BoolOptPtr(&opts.disableJunitReports, "no-junit", false, "Disable generation of junit reports when running tests")
+
 	opts.dryRun = true
 	opts.forceRebuild = true
 

--- a/dag/dag.go
+++ b/dag/dag.go
@@ -3,7 +3,9 @@ package dag
 import (
 	"fmt"
 	"os"
+	"path"
 	"path/filepath"
+	"strings"
 	"sync"
 
 	"github.com/radiofrance/dib/types"
@@ -20,16 +22,18 @@ type DAG struct {
 	TestRunners []types.TestRunner
 }
 
-func (dag *DAG) GenerateDAG(buildPath string, registryPrefix string) {
+func (dag *DAG) GenerateDAG(workingDir, buildRelativePath string, registryPrefix string) {
 	cache := make(map[string]*Image)
+	buildFullPath := path.Join(workingDir, buildRelativePath)
 
 	allParents := make(map[string][]string)
-	err := filepath.Walk(buildPath, func(filePath string, info os.FileInfo, err error) error {
+	err := filepath.Walk(buildFullPath, func(filePath string, info os.FileInfo, err error) error {
 		if err != nil {
 			return err
 		}
 		if dockerfile.IsDockerfile(filePath) {
 			dckfile, err := dockerfile.ParseDockerfile(filePath)
+			dckfile.ContextRelativePath = strings.ReplaceAll(filePath, workingDir+"/", "")
 			if err != nil {
 				return err
 			}

--- a/dag/dag.go
+++ b/dag/dag.go
@@ -5,7 +5,6 @@ import (
 	"os"
 	"path"
 	"path/filepath"
-	"strings"
 	"sync"
 
 	"github.com/radiofrance/dib/types"
@@ -36,7 +35,6 @@ func (dag *DAG) GenerateDAG(workingDir, buildRelativePath string, registryPrefix
 			if err != nil {
 				return err
 			}
-			dckfile.ContextRelativePath = strings.ReplaceAll(filePath, workingDir+"/", "")
 
 			skipBuild, hasSkipLabel := dckfile.Labels["skipbuild"]
 			if hasSkipLabel && skipBuild == "true" {

--- a/dag/dag_test.go
+++ b/dag/dag_test.go
@@ -114,10 +114,8 @@ func Test_GenerateDAG(t *testing.T) {
 		t.Fatal("Failed to get current working directory.")
 	}
 
-	buildPath := path.Join(cwd, "../test/fixtures/docker")
-
 	DAG := dag.DAG{}
-	DAG.GenerateDAG(buildPath, "eu.gcr.io/my-test-repository")
+	DAG.GenerateDAG(path.Join(cwd, ".."), "test/fixtures/docker", "eu.gcr.io/my-test-repository")
 
 	assert.Len(t, DAG.Images, 1)
 

--- a/dag/image.go
+++ b/dag/image.go
@@ -38,26 +38,23 @@ type Image struct {
 }
 
 type BuildReport struct {
-	ImageName                 string
-	BuildSuccess              bool
-	FailureMessage            string
-	DockerContextRelativePath string
+	ImageName      string
+	BuildSuccess   bool
+	FailureMessage string
 }
 
-func (img *Image) buildFailedReport(msg string) BuildReport {
+func (img Image) buildFailedReport(msg string) BuildReport {
 	return BuildReport{
-		BuildSuccess:              false,
-		DockerContextRelativePath: img.Dockerfile.ContextRelativePath,
-		ImageName:                 img.ShortName,
-		FailureMessage:            msg,
+		BuildSuccess:   false,
+		ImageName:      img.ShortName,
+		FailureMessage: msg,
 	}
 }
 
-func (img *Image) buildSucceededReport() BuildReport {
+func (img Image) buildSucceededReport() BuildReport {
 	return BuildReport{
-		BuildSuccess:              true,
-		DockerContextRelativePath: img.Dockerfile.ContextRelativePath,
-		ImageName:                 img.ShortName,
+		BuildSuccess: true,
+		ImageName:    img.ShortName,
 	}
 }
 
@@ -183,10 +180,9 @@ func findRevision() string {
 func (img *Image) runTests(ref string) error {
 	for _, runner := range img.TestRunners {
 		if err := runner.RunTest(types.RunTestOptions{
-			ImageName:                 img.ShortName,
-			ImageReference:            ref,
-			DockerContextFullPath:     img.Dockerfile.ContextPath,
-			DockerContextRelativePath: img.Dockerfile.ContextRelativePath,
+			ImageName:         img.ShortName,
+			ImageReference:    ref,
+			DockerContextPath: img.Dockerfile.ContextPath,
 		}); err != nil {
 			return err
 		}

--- a/dag/image.go
+++ b/dag/image.go
@@ -134,7 +134,7 @@ func (img *Image) doRebuild(newTag string, localOnly, disableRunTests bool) erro
 	}
 
 	logrus.Infof("Running tests for \"%s:%s\"", img.Name, newTag)
-	return img.runTests(fmt.Sprintf("%s:%s", img.Name, newTag), img.Dockerfile.ContextPath)
+	return img.runTests(fmt.Sprintf("%s:%s", img.Name, newTag))
 }
 
 func findSource() string {
@@ -165,9 +165,14 @@ func findRevision() string {
 }
 
 // runTests run docker tests for each TestRunner.
-func (img *Image) runTests(ref, path string) error {
+func (img *Image) runTests(ref string) error {
 	for _, runner := range img.TestRunners {
-		if err := runner.RunTest(ref, path); err != nil {
+		if err := runner.RunTest(types.RunTestOptions{
+			ImageName:                 img.ShortName,
+			ImageReference:            ref,
+			DockerContextFullPath:     img.Dockerfile.ContextPath,
+			DockerContextRelativePath: img.Dockerfile.ContextRelativePath,
+		}); err != nil {
 			return err
 		}
 	}

--- a/dag/image_test.go
+++ b/dag/image_test.go
@@ -21,7 +21,7 @@ func Test_RebuildRefExists(t *testing.T) {
 	builder := &mock.Builder{}
 	img := createImage(registry, builder, nil)
 
-	reportChan := make(chan dag.BuildReport, 100)
+	reportChan := make(chan dag.BuildReport, 1)
 	wg := sync.WaitGroup{}
 	wg.Add(1)
 	img.Rebuild("new-123", false, true, false, &wg, &reportChan)
@@ -44,7 +44,7 @@ func Test_RebuildForce(t *testing.T) {
 	builder := &mock.Builder{}
 	img := createImage(registry, builder, nil)
 
-	reportChan := make(chan dag.BuildReport, 100)
+	reportChan := make(chan dag.BuildReport, 1)
 	wg := sync.WaitGroup{}
 	wg.Add(1)
 	img.Rebuild("new-123", true, false, false, &wg, &reportChan)
@@ -68,7 +68,7 @@ func TestImage_runTests(t *testing.T) {
 	tester := &mock.TestRunner{}
 	img := createImage(registry, builder, tester)
 
-	reportChan := make(chan dag.BuildReport, 100)
+	reportChan := make(chan dag.BuildReport, 1)
 	wg := sync.WaitGroup{}
 	wg.Add(1)
 	img.Rebuild("new-123", true, true, false, &wg, &reportChan)

--- a/dgoss/dgoss.go
+++ b/dgoss/dgoss.go
@@ -1,27 +1,69 @@
 package dgoss
 
 import (
+	"bytes"
 	"errors"
 	"fmt"
+	"io/ioutil"
 	"os"
 	"path"
+	"strings"
+
+	"github.com/sirupsen/logrus"
+
+	"github.com/radiofrance/dib/types"
 
 	"github.com/radiofrance/dib/exec"
 )
 
 // TestRunner implements types.TestRunner.
-type TestRunner struct{}
+type TestRunner struct {
+	ReportsDirectory string
+}
+
+// NewTestRunner creates a new instance of TestRunner.
+func NewTestRunner(reportsDirectory string) TestRunner {
+	return TestRunner{
+		ReportsDirectory: reportsDirectory,
+	}
+}
 
 // RunTest executes goss tests on the given image. goss.yaml file is expected to be present in the given path.
-func (b TestRunner) RunTest(ref, filePath string) error {
+func (b TestRunner) RunTest(opts types.RunTestOptions) error {
 	shell := &exec.ShellExecutor{
-		Dir: filePath,
+		Dir: opts.DockerContextFullPath,
+		Env: append(os.Environ(), "GOSS_OPTS=--format junit"),
 	}
 
-	if _, err := os.Stat(path.Join(filePath, "goss.yaml")); err == nil {
-		return shell.ExecuteStdout("/bin/bash", "-c", fmt.Sprintf("dgoss run %s yes", ref))
+	if _, err := os.Stat(path.Join(opts.DockerContextFullPath, "goss.yaml")); err == nil {
+		var stdout, stderr bytes.Buffer
+		testError := shell.ExecuteWithBuffers(&stdout, &stderr, "/bin/bash", "-c",
+			fmt.Sprintf("dgoss run %s yes", opts.ImageReference))
+		if err := exportJunitReport(opts, stdout.String(), b); err != nil {
+			return err
+		}
+
+		if testError != nil {
+			logrus.Error(stderr.String())
+			return testError
+		}
 	} else if !errors.Is(err, os.ErrNotExist) {
 		return err
+	}
+	return nil
+}
+
+func exportJunitReport(opts types.RunTestOptions, stdout string, b TestRunner) error {
+	stdout = strings.ReplaceAll(stdout, "<testcase name=\"", fmt.Sprintf(
+		"<testcase classname=\"goss-%s\" file=\"%s\" name=\"", opts.ImageName, opts.DockerContextRelativePath))
+
+	if err := os.MkdirAll(b.ReportsDirectory, 0755); err != nil {
+		return fmt.Errorf("could not create directory %s: %w", b.ReportsDirectory, err)
+	}
+
+	junitFilename := path.Join(b.ReportsDirectory, fmt.Sprintf("junit-%s.xml", opts.ImageName))
+	if err := ioutil.WriteFile(junitFilename, []byte(stdout), 0644); err != nil {
+		return fmt.Errorf("could not write junit report to file %s: %w", junitFilename, err)
 	}
 	return nil
 }

--- a/dgoss/dgoss.go
+++ b/dgoss/dgoss.go
@@ -9,8 +9,6 @@ import (
 	"path"
 	"strings"
 
-	"github.com/sirupsen/logrus"
-
 	"github.com/radiofrance/dib/types"
 
 	"github.com/radiofrance/dib/exec"
@@ -40,29 +38,28 @@ func (b TestRunner) RunTest(opts types.RunTestOptions) error {
 		testError := shell.ExecuteWithBuffers(&stdout, &stderr, "/bin/bash", "-c",
 			fmt.Sprintf("dgoss run %s yes", opts.ImageReference))
 		if err := exportJunitReport(opts, stdout.String(), b); err != nil {
-			return err
+			return fmt.Errorf("dgoss tests failed, could not export junit report: %w", err)
 		}
 
 		if testError != nil {
-			logrus.Error(stderr.String())
-			return testError
+			return fmt.Errorf("dgoss tests failed: %w", testError)
 		}
 	} else if !errors.Is(err, os.ErrNotExist) {
-		return err
+		return fmt.Errorf("dgoss tests failed: %w", err)
 	}
 	return nil
 }
 
-func exportJunitReport(opts types.RunTestOptions, stdout string, b TestRunner) error {
+func exportJunitReport(opts types.RunTestOptions, stdout string, testRunner TestRunner) error {
 	stdout = strings.ReplaceAll(stdout, "<testcase name=\"", fmt.Sprintf(
 		"<testcase classname=\"goss-%s\" file=\"%s\" name=\"", opts.ImageName, opts.DockerContextRelativePath))
 
-	if err := os.MkdirAll(b.ReportsDirectory, 0755); err != nil {
-		return fmt.Errorf("could not create directory %s: %w", b.ReportsDirectory, err)
+	if err := os.MkdirAll(testRunner.ReportsDirectory, 0o755); err != nil {
+		return fmt.Errorf("could not create directory %s: %w", testRunner.ReportsDirectory, err)
 	}
 
-	junitFilename := path.Join(b.ReportsDirectory, fmt.Sprintf("junit-%s.xml", opts.ImageName))
-	if err := ioutil.WriteFile(junitFilename, []byte(stdout), 0644); err != nil {
+	junitFilename := path.Join(testRunner.ReportsDirectory, fmt.Sprintf("junit-%s.xml", opts.ImageName))
+	if err := ioutil.WriteFile(junitFilename, []byte(stdout), 0o600); err != nil {
 		return fmt.Errorf("could not write junit report to file %s: %w", junitFilename, err)
 	}
 	return nil

--- a/dockerfile/dockerfile.go
+++ b/dockerfile/dockerfile.go
@@ -29,10 +29,11 @@ func init() {
 
 // Dockerfile holds the information from a Dockerfile.
 type Dockerfile struct {
-	ContextPath string
-	Filename    string
-	From        []string
-	Labels      map[string]string
+	ContextPath         string
+	ContextRelativePath string
+	Filename            string
+	From                []string
+	Labels              map[string]string
 }
 
 func (d *Dockerfile) addFrom(from string) {

--- a/dockerfile/dockerfile.go
+++ b/dockerfile/dockerfile.go
@@ -29,11 +29,10 @@ func init() {
 
 // Dockerfile holds the information from a Dockerfile.
 type Dockerfile struct {
-	ContextPath         string
-	ContextRelativePath string
-	Filename            string
-	From                []string
-	Labels              map[string]string
+	ContextPath string
+	Filename    string
+	From        []string
+	Labels      map[string]string
 }
 
 func (d *Dockerfile) addFrom(from string) {

--- a/exec/shell.go
+++ b/exec/shell.go
@@ -3,6 +3,7 @@ package exec
 import (
 	"bytes"
 	"fmt"
+	"io"
 	"os"
 	"os/exec"
 )
@@ -13,8 +14,8 @@ type Executor interface {
 	Execute(name string, args ...string) (string, error)
 	// ExecuteStdout executes a command and prints the standard output instead of returning it.
 	ExecuteStdout(name string, args ...string) error
-	// ExecuteWithBuffers executes a command and forwards stdout and stderr
-	ExecuteWithBuffers(stdout, stderr *bytes.Buffer, name string, args ...string) error
+	// ExecuteWithWriters executes a command and forwards stdout and stderr to an io.Writer
+	ExecuteWithWriters(stdout, stderr io.Writer, name string, args ...string) error
 }
 
 // ShellExecutor is an implementation of Executor that uses the standard exec package to run shell commands.
@@ -40,7 +41,7 @@ func (e ShellExecutor) Execute(name string, args ...string) (string, error) {
 	return stdout.String(), nil
 }
 
-func (e ShellExecutor) ExecuteWithBuffers(stdout, stderr *bytes.Buffer, name string, args ...string) error {
+func (e ShellExecutor) ExecuteWithWriters(stdout, stderr io.Writer, name string, args ...string) error {
 	cmd := exec.Command(name, args...)
 	cmd.Env = e.Env
 

--- a/exec/shell.go
+++ b/exec/shell.go
@@ -13,16 +13,20 @@ type Executor interface {
 	Execute(name string, args ...string) (string, error)
 	// ExecuteStdout executes a command and prints the standard output instead of returning it.
 	ExecuteStdout(name string, args ...string) error
+	// ExecuteWithBuffers executes a command and forwards stdout and stderr
+	ExecuteWithBuffers(stdout, stderr *bytes.Buffer, name string, args ...string) error
 }
 
 // ShellExecutor is an implementation of Executor that uses the standard exec package to run shell commands.
 type ShellExecutor struct {
 	Dir string
+	Env []string
 }
 
 // Execute a shell command and return the standard output.
 func (e ShellExecutor) Execute(name string, args ...string) (string, error) {
 	cmd := exec.Command(name, args...)
+	cmd.Env = e.Env
 
 	var stdout, stderr bytes.Buffer
 	cmd.Stderr = &stderr
@@ -36,9 +40,26 @@ func (e ShellExecutor) Execute(name string, args ...string) (string, error) {
 	return stdout.String(), nil
 }
 
+func (e ShellExecutor) ExecuteWithBuffers(stdout, stderr *bytes.Buffer, name string, args ...string) error {
+	cmd := exec.Command(name, args...)
+	cmd.Env = e.Env
+
+	cmd.Stderr = stderr
+	cmd.Stdout = stdout
+	cmd.Dir = e.Dir
+
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("failed to execute command `%s`: %w", name, err)
+	}
+
+	return nil
+}
+
 // ExecuteStdout executes a shell command and prints to the standard output.
 func (e ShellExecutor) ExecuteStdout(name string, args ...string) error {
 	cmd := exec.Command(name, args...)
+	cmd.Env = e.Env
+
 	cmd.Stderr = os.Stderr
 	cmd.Stdout = os.Stdout
 	cmd.Dir = e.Dir

--- a/graphviz/graphviz_test.go
+++ b/graphviz/graphviz_test.go
@@ -22,10 +22,8 @@ func Test_GenerateDotviz(t *testing.T) {
 		t.Fatal("Failed to get current working directory.")
 	}
 
-	buildPath := path.Join(cwd, "../test/fixtures/docker")
-
 	DAG := dag.DAG{}
-	DAG.GenerateDAG(buildPath, "eu.gcr.io/my-test-repository")
+	DAG.GenerateDAG(path.Join(cwd, ".."), "test/fixtures/docker", "eu.gcr.io/my-test-repository")
 
 	dir, err := ioutil.TempDir("/tmp", "dib-test")
 	if err != nil {

--- a/mock/testrunner.go
+++ b/mock/testrunner.go
@@ -1,10 +1,12 @@
 package mock
 
+import "github.com/radiofrance/dib/types"
+
 type TestRunner struct {
 	CallCount int
 }
 
-func (t *TestRunner) RunTest(_, _ string) error {
+func (t *TestRunner) RunTest(_ types.RunTestOptions) error {
 	t.CallCount++
 	return nil
 }

--- a/types/types.go
+++ b/types/types.go
@@ -1,6 +1,8 @@
 package types
 
-import "time"
+import (
+	"time"
+)
 
 // ImageBuilder is the interface for building Docker images.
 type ImageBuilder interface {
@@ -32,7 +34,14 @@ type ImageTagger interface {
 
 // TestRunner is an interface for dealing with docker tests, such as dgoss, trivy.
 type TestRunner interface {
-	RunTest(ref, path string) error
+	RunTest(opts RunTestOptions) error
+}
+
+type RunTestOptions struct {
+	ImageName                 string
+	ImageReference            string
+	DockerContextFullPath     string
+	DockerContextRelativePath string
 }
 
 // DockerRegistry is an interface for dealing with docker registries.

--- a/types/types.go
+++ b/types/types.go
@@ -38,10 +38,9 @@ type TestRunner interface {
 }
 
 type RunTestOptions struct {
-	ImageName                 string
-	ImageReference            string
-	DockerContextFullPath     string
-	DockerContextRelativePath string
+	ImageName         string
+	ImageReference    string
+	DockerContextPath string
 }
 
 // DockerRegistry is an interface for dealing with docker registries.


### PR DESCRIPTION
Exemple of output

```
[13:16:32][INFO] Build report
[13:16:32][INFO]        [cypress-browsers-node16]: SUCCESS
[13:16:32][INFO]        [golang17-ci]: SUCCESS
[13:16:32][INFO]        [logstash-verifier]: SUCCESS
[13:16:32][INFO]        [nodejs14-cypress]: SUCCESS
[13:16:32][INFO]        [gatling]: SUCCESS
[13:16:32][INFO]        [nodejs16-playwright]: SUCCESS
[13:16:32][INFO]        [nodejs16-ci]: SUCCESS
[13:16:32][ERRO]        [nodejs12-chrome-puppeteer]: FAILURE: dgoss tests failed: failed to execute command `/bin/bash`: exit status 1
[13:16:32][INFO]        [sonar-scanner]: SUCCESS
[13:16:32][INFO]        [golang17-goreleaser]: SUCCESS
[13:16:32][INFO]        [sonar-scanner-python3.9]: SUCCESS
[13:16:32][INFO]        [sonar-scanner-php7.1]: SUCCESS
[13:16:32][INFO]        [sonar-scanner-php8.1]: SUCCESS
[13:16:32][INFO]        [sonar-scanner-nodejs14]: SUCCESS
[13:16:32][INFO]        [sonar-scanner-nodejs12]: SUCCESS
[13:16:32][INFO]        [sonar-scanner-golang17]: SUCCESS
[13:16:32][INFO]        [sonar-scanner-php7.4]: SUCCESS
[13:16:32][INFO]        [sonar-scanner-nodejs10]: SUCCESS
[13:16:32][INFO]        [sonar-scanner-php7.1-node10]: SUCCESS
[13:16:32][INFO]        [sonar-scanner-nodejs16]: SUCCESS
[13:16:32][INFO]        [sonar-scanner-php8.0]: SUCCESS
```

dgoss junit artifacts can now be added parsed as classis unit tests. See example for a gitlab-ci job 

```
  artifacts:
    when: always
    reports:
      junit:
      - dist/testresults/goss/*.xml
```
<img width="953" alt="Capture d’écran 2022-01-19 à 13 24 25" src="https://user-images.githubusercontent.com/455944/150128885-0cf8f79b-906b-40a1-9c28-616365e7666e.png">
<img width="1277" alt="Capture d’écran 2022-01-19 à 13 26 33" src="https://user-images.githubusercontent.com/455944/150129198-39cddaeb-cb0e-4db0-96b8-c84f4ab658a1.png">



