### PR TITLE
chore(ci): rename CI workflow and fix status badge URL

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,12 +1,10 @@
-name: Go
+name: CI
 
 on:
   pull_request:
   push:
     branches:
     - "main"
-    tags:
-    - '*'
 
 jobs:
   lint:
@@ -24,6 +22,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@ec3a7ce113134d7a93b817d10a8272cb61118579 # renovate: tag=v2.4.0
+        with:
+          fetch-depth: 2 # See https://community.codecov.com/t/issue-detecting-commit-sha-please-run-actions-checkout-with-fetch-depth-1-or-set-to-0/2571
       - uses: actions/setup-go@331ce1d993939866bb63c32c6cbbfd48fa76fc57 # renovate: tag=v2.1.4
         with:
           go-version: 1.17.x

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # DIB (Docker Image Builder)
 
-![CI Status](https://img.shields.io/github/workflow/status/radiofrance/dib/go?label=CI&logo=github%20actions&logoColor=fff)
+![CI Status](https://img.shields.io/github/workflow/status/radiofrance/dib/CI?label=CI&logo=github%20actions&logoColor=fff)
 [![codecov](https://codecov.io/gh/radiofrance/dib/branch/main/graph/badge.svg)](https://codecov.io/gh/radiofrance/dib)
 [![Go Reference](https://pkg.go.dev/badge/github.com/radiofrance/dib.svg)](https://pkg.go.dev/github.com/radiofrance/dib)
 ![GitHub release (latest SemVer)](https://img.shields.io/github/v/release/radiofrance/dib?sort=semver)


### PR DESCRIPTION
I think the workflow that runs the checks can be renamed to `CI` as it best describes its role