### PR TITLE
feat(kaniko): source configuration from file and env

### DIFF
--- a/cmd/hash.go
+++ b/cmd/hash.go
@@ -18,7 +18,7 @@ var hashCmd = &cobra.Command{
 contains all Dockerfiles. If no argument is passed to dib hash, it will use 'docker' as the directory name`,
 	Args: cobra.MaximumNArgs(1),
 	Run: func(cmd *cobra.Command, args []string) {
-		hash, err := versionpkg.GetDockerVersionHash(viper.GetString(keyBuildPath))
+		hash, err := versionpkg.GetDockerVersionHash(viper.GetString("build_path"))
 		if err != nil {
 			log.Fatal(err)
 		}

--- a/cmd/logger.go
+++ b/cmd/logger.go
@@ -8,19 +8,17 @@ import (
 	"strings"
 	"time"
 
-	"github.com/spf13/cobra"
-
-	"github.com/spf13/viper"
-
-	"golang.org/x/term"
-
 	"github.com/sirupsen/logrus"
+	"github.com/spf13/cobra"
+	"github.com/spf13/viper"
+	"golang.org/x/term"
 )
 
 func initLogLevel() {
-	logrusLvl, err := logrus.ParseLevel(viper.GetString(keyLogLevel))
+	rawLvl := viper.GetString("log_level")
+	logrusLvl, err := logrus.ParseLevel(rawLvl)
 	if err != nil {
-		fmt.Printf("Invalid log level %s\n", viper.GetString(keyLogLevel)) //nolint:forbidigo
+		fmt.Printf("Invalid log level %s\n", rawLvl) //nolint:forbidigo
 		cobra.CheckErr(err)
 	}
 

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -7,31 +7,20 @@ import (
 	"strings"
 
 	"github.com/spf13/cobra"
-
+	"github.com/spf13/pflag"
 	"github.com/spf13/viper"
 )
 
-var cfgFile string
-
 const (
-	defaultRegistryURL      = "eu.gcr.io/my-test-repository"
-	defaultReferentialImage = "dib-referential"
-	defaultLogLevel         = "info"
-	defaultBuildPath        = "docker"
-
-	keyBackend          = "Backend"
-	keyLocalOnly        = "local-only"
-	keyDisableGraph     = "no-graph"
-	keyDisableJUnit     = "no-junit"
-	keyDisableTests     = "no-tests"
-	keyBuildPath        = "build-path"
-	keyDryRun           = "dry-run"
-	keyRegistryURL      = "registry-url"
-	keyForceRebuild     = "force-rebuild"
-	keyRetagLatest      = "retag-latest"
-	keyReferentialImage = "referential-image"
-	keyLogLevel         = "log-level"
+	defaultRegistryURL         = "eu.gcr.io/my-test-repository"
+	defaultReferentialImage    = "dib-referential"
+	defaultLogLevel            = "info"
+	defaultBuildPath           = "docker"
+	defaultKanikoImage         = "gcr.io/kaniko-project/executor:v1.7.0"
+	defaultKubernetesNamespace = "default"
 )
+
+var cfgFile string
 
 // rootCmd represents the base command when called without any subcommands.
 var rootCmd = &cobra.Command{
@@ -59,15 +48,15 @@ It is also required that one of the directories in this path contains a .docker-
 be considered as the root directory for the hash generation and comparison`
 
 	rootCmd.PersistentFlags().StringVar(&cfgFile, "config", "", "config file (default is $HOME/.config/.dib.yaml)")
-	rootCmd.PersistentFlags().String(keyBuildPath, defaultBuildPath, desc)
-	rootCmd.PersistentFlags().String(keyRegistryURL, defaultRegistryURL, "Docker registry URL where images are stored.")
-	rootCmd.PersistentFlags().String(keyReferentialImage, defaultReferentialImage, "Name of an image on "+
+	rootCmd.PersistentFlags().String("build-path", defaultBuildPath, desc)
+	rootCmd.PersistentFlags().String("registry-url", defaultRegistryURL, "Docker registry URL where images are stored.")
+	rootCmd.PersistentFlags().String("referential-image", defaultReferentialImage, "Name of an image on "+
 		"the registry. This image will be used as a reference for checking build completion of previous dib runs. "+
 		"Tags will be added to this image but it has no other purpose.")
-	rootCmd.PersistentFlags().StringP(keyLogLevel, "l", defaultLogLevel, "Log level. Can be any level "+
+	rootCmd.PersistentFlags().StringP("log-level", "l", defaultLogLevel, "Log level. Can be any level "+
 		"supported by logrus (\"info\", \"debug\", etc...)")
 
-	_ = viper.BindPFlags(rootCmd.PersistentFlags())
+	bindPFlagsSnakeCase(rootCmd.PersistentFlags())
 }
 
 // initConfig reads in config file and ENV variables if set.
@@ -89,10 +78,16 @@ func initConfig() {
 		viper.AddConfigPath(workingDir)
 	}
 
+	// Set defaults for config values that have no flag bound to them.
+	viper.SetDefault("kaniko.executor.docker.image", defaultKanikoImage)
+	viper.SetDefault("kaniko.executor.kubernetes.image", defaultKanikoImage)
+	viper.SetDefault("kaniko.executor.kubernetes.namespace", defaultKubernetesNamespace)
+
+	// Env vars starting with the DIB_ prefix can override any configuration.
+	// e.g. DIB_LOG_LEVEL, DIB_KANIKO_CONTEXT_S3_BUCKET, etc...
 	viper.SetEnvPrefix("dib")
-	viper.SetEnvKeyReplacer(strings.NewReplacer("-", "_"))
-	viper.SetDefault(keyBuildPath, "docker")
-	viper.AutomaticEnv() // read in environment variables that match
+	viper.SetEnvKeyReplacer(strings.NewReplacer(".", "_")) // Allows to override any sub-level in file config.
+	viper.AutomaticEnv()                                   // read in environment variables that match
 
 	// If a config file is found, read it in.
 	if err := viper.ReadInConfig(); err == nil {
@@ -109,31 +104,61 @@ func getWorkingDir() (string, error) {
 }
 
 type BuildOpts struct {
-	BuildPath            string
-	DisableGenerateGraph bool
-	DisableJunitReports  bool
-	DisableRunTests      bool
-	DryRun               bool
-	ForceRebuild         bool
-	LocalOnly            bool
-	ReferentialImage     string
-	RegistryURL          string
-	RetagLatest          bool
-	Backend              string
+	BuildPath            string       `mapstructure:"build_path"`
+	DisableGenerateGraph bool         `mapstructure:"disable_generate_graph"`
+	DisableJunitReports  bool         `mapstructure:"disable_junit_reports"`
+	DisableRunTests      bool         `mapstructure:"disable_run_tests"`
+	DryRun               bool         `mapstructure:"dry_run"`
+	ForceRebuild         bool         `mapstructure:"force_rebuild"`
+	LocalOnly            bool         `mapstructure:"local_only"`
+	ReferentialImage     string       `mapstructure:"referential_image"`
+	RegistryURL          string       `mapstructure:"registry_url"`
+	RetagLatest          bool         `mapstructure:"retag_latest"`
+	Backend              string       `mapstructure:"backend"`
+	Kaniko               KanikoConfig `mapstructure:"kaniko"`
+}
+
+// KanikoConfig holds the configuration for the Kaniko build backend.
+type KanikoConfig struct {
+	Context struct {
+		S3 struct {
+			Bucket string `mapstructure:"bucket"`
+			Region string `mapstructure:"region"`
+		} `mapstructure:"s3"`
+	} `mapstructure:"context"`
+	Executor struct {
+		Docker struct {
+			Image string `mapstructure:"image"`
+		} `mapstructure:"docker"`
+		Kubernetes struct {
+			Namespace           string   `mapstructure:"namespace"`
+			Image               string   `mapstructure:"image"`
+			DockerConfigSecret  string   `mapstructure:"docker_config_secret"`
+			ImagePullSecrets    []string `mapstructure:"image_pull_secrets"`
+			EnvSecrets          []string `mapstructure:"env_secrets"`
+			ContainerOverride   string   `mapstructure:"container_override"`
+			PodTemplateOverride string   `mapstructure:"pod_template_override"`
+		} `mapstructure:"kubernetes"`
+	} `mapstructure:"executor"`
 }
 
 func buildOptsFromViper() BuildOpts {
-	return BuildOpts{
-		BuildPath:            viper.GetString(keyBuildPath),
-		DisableGenerateGraph: viper.GetBool(keyDisableGraph),
-		DisableJunitReports:  viper.GetBool(keyDisableJUnit),
-		DisableRunTests:      viper.GetBool(keyDisableTests),
-		DryRun:               viper.GetBool(keyDryRun),
-		ForceRebuild:         viper.GetBool(keyForceRebuild),
-		LocalOnly:            viper.GetBool(keyLocalOnly),
-		ReferentialImage:     viper.GetString(keyReferentialImage),
-		RegistryURL:          viper.GetString(keyRegistryURL),
-		RetagLatest:          viper.GetBool(keyRetagLatest),
-		Backend:              viper.GetString(keyBackend),
-	}
+	opts := BuildOpts{}
+
+	// This copies all the viper values into our config struct.
+	// The mapping between viper identifiers and struct field names
+	// is ensured by `mapstructure` struct tags.
+	_ = viper.Unmarshal(&opts)
+
+	return opts
+}
+
+// bindPFlagsSnakeCase binds the flags with viper values. The identifier of the viper value
+// is the name of the flag with dashes replaced by underscores. This is required so we can
+// retrieve values from viper with the same behaviour with config coming from files
+// (my_config: "value") or from flags (--my-config=value).
+func bindPFlagsSnakeCase(flags *pflag.FlagSet) {
+	flags.VisitAll(func(flag *pflag.Flag) {
+		_ = viper.BindPFlag(strings.ReplaceAll(flag.Name, "-", "_"), flag)
+	})
 }

--- a/test/fixtures/.dib-config.yml
+++ b/test/fixtures/.dib-config.yml
@@ -1,1 +1,42 @@
-build_path: docker
+build_path: dockerfiles
+registry_url: gcr.io/project-id
+log_level: debug
+kaniko:
+  context:
+    s3:
+      bucket: my-bucket
+      region: eu-west-3
+  executor:
+    docker:
+      config: /tmp/docker/config.json
+    kubernetes:
+      namespace: kaniko
+      image_pull_secrets:
+        - regcreds
+      env_secrets:
+        - kanikoroawssecret
+      docker_config_secret: kanikoroawssecret
+      container_override: |
+        resources:
+          limits:
+            cpu: 2
+            memory: 2Gi
+          requests:
+            cpu: 1
+            memory: 1Gi
+      pod_template_override: |
+        spec:
+          affinity:
+            nodeAffinity:
+              requiredDuringSchedulingIgnoredDuringExecution:
+                nodeSelectorTerms:
+                - matchExpressions:
+                  - key: kops.k8s.io/instancegroup
+                    operator: In
+                    values:
+                    - nodes_spot
+          tolerations:
+          - effect: NoSchedule
+            key: dedicated
+            operator: Equal
+            value: spot


### PR DESCRIPTION
## Features

- Moved hardcoded config for the Kaniko build backend to `viper` configuration.
- Any config can be overridden by environment variables, even when multiple levels of hierarchy :
  ```yaml
  kaniko:
    context:
      s3:
        bucket: "bucket-name"
  ```
  can be overriden with `DIB_KANIKO_CONTEXT_S3_BUCKET=other-bucket`

- Kaniko backend cannot be configured with flags: this is volontary to prevent having too many flags. Might be added later if requested.
  Other "normal" configuration can be done using either:
  - Flag: `--registry-url`
  - Env var: `DIB_REGISTRY_URL`
  - File: `registry_url`

## Breaking Changes:

- Config keys in `yaml` file now use the `snake_case` format, instead of `kebab-case`