### PR TITLE
feat(tests): print test report

### DIFF
--- a/dag/dag.go
+++ b/dag/dag.go
@@ -154,19 +154,7 @@ func (dag *DAG) Rebuild(newTag string, forceRebuild, disableRunTests, localOnly 
 		reports = append(reports, report)
 	}
 
-	logrus.Info("Build report")
-	var hasError bool
-	for _, report := range reports {
-		if report.BuildSuccess {
-			logrus.Infof("\t[%s]: SUCCESS", report.ImageName)
-		} else {
-			hasError = true
-			logrus.Errorf("\t[%s]: FAILURE: %s", report.ImageName, report.FailureMessage)
-		}
-	}
+	printReports(reports)
 
-	if hasError {
-		return fmt.Errorf("one of the image build failed, see logs for more details")
-	}
-	return nil
+	return checkError(reports)
 }

--- a/dag/image_test.go
+++ b/dag/image_test.go
@@ -4,14 +4,11 @@ import (
 	"sync"
 	"testing"
 
-	"github.com/radiofrance/dib/types"
-
-	"github.com/stretchr/testify/assert"
-
-	"github.com/radiofrance/dib/dockerfile"
-
 	"github.com/radiofrance/dib/dag"
+	"github.com/radiofrance/dib/dockerfile"
 	"github.com/radiofrance/dib/mock"
+	"github.com/radiofrance/dib/types"
+	"github.com/stretchr/testify/assert"
 )
 
 func Test_RebuildRefExists(t *testing.T) {
@@ -29,7 +26,8 @@ func Test_RebuildRefExists(t *testing.T) {
 	close(reportChan)
 
 	for report := range reportChan {
-		assert.True(t, report.BuildSuccess)
+		assert.Equal(t, dag.BuildStatusSkipped, report.BuildStatus)
+		assert.Equal(t, dag.TestsStatusSkipped, report.TestsStatus)
 	}
 
 	assert.Equal(t, 1, registry.RefExistsCallCount)
@@ -52,7 +50,8 @@ func Test_RebuildForce(t *testing.T) {
 	close(reportChan)
 
 	for report := range reportChan {
-		assert.True(t, report.BuildSuccess)
+		assert.Equal(t, dag.BuildStatusSuccess, report.BuildStatus)
+		assert.Equal(t, dag.TestsStatusPassed, report.TestsStatus)
 	}
 
 	assert.Equal(t, 1, registry.RefExistsCallCount)
@@ -71,12 +70,13 @@ func TestImage_runTests(t *testing.T) {
 	reportChan := make(chan dag.BuildReport, 1)
 	wg := sync.WaitGroup{}
 	wg.Add(1)
-	img.Rebuild("new-123", true, true, false, &wg, &reportChan)
+	img.Rebuild("new-123", true, false, false, &wg, &reportChan)
 	wg.Wait()
 	close(reportChan)
 
 	for report := range reportChan {
-		assert.True(t, report.BuildSuccess)
+		assert.Equal(t, dag.BuildStatusSuccess, report.BuildStatus)
+		assert.Equal(t, dag.TestsStatusPassed, report.TestsStatus)
 	}
 
 	assert.Equal(t, 1, registry.RefExistsCallCount)

--- a/dag/report.go
+++ b/dag/report.go
@@ -1,0 +1,82 @@
+package dag
+
+import (
+	"fmt"
+
+	"github.com/sirupsen/logrus"
+)
+
+const (
+	BuildStatusSkipped BuildStatus = iota
+	BuildStatusSuccess
+	BuildStatusError
+)
+
+const (
+	TestsStatusSkipped TestsStatus = iota
+	TestsStatusPassed
+	TestsStatusFailed
+)
+
+type (
+	BuildStatus int
+	TestsStatus int
+)
+
+// BuildReport holds the status of the build/tests.
+type BuildReport struct {
+	ImageName      string
+	BuildStatus    BuildStatus
+	TestsStatus    TestsStatus
+	FailureMessage string
+}
+
+// withError returns a BuildReport .
+func (r BuildReport) withError(err error) BuildReport {
+	r.BuildStatus = BuildStatusError
+	r.FailureMessage = err.Error()
+
+	return r
+}
+
+// printReports prints the reports to the user.
+func printReports(reports []BuildReport) {
+	logrus.Info("Build report")
+	for _, report := range reports {
+		switch report.BuildStatus {
+		case BuildStatusSuccess:
+			logrus.Infof("\t[%s]: SUCCESS", report.ImageName)
+		case BuildStatusSkipped:
+			logrus.Infof("\t[%s]: SKIPPED", report.ImageName)
+		case BuildStatusError:
+			logrus.Errorf("\t[%s]: FAILURE: %s", report.ImageName, report.FailureMessage)
+		}
+	}
+
+	logrus.Info("Tests report")
+	for _, report := range reports {
+		switch report.TestsStatus {
+		case TestsStatusPassed:
+			logrus.Infof("\t[%s]: PASSED", report.ImageName)
+		case TestsStatusSkipped:
+			logrus.Infof("\t[%s]: SKIPPED", report.ImageName)
+		case TestsStatusFailed:
+			logrus.Errorf("\t[%s]: FAILED: %s", report.ImageName, report.FailureMessage)
+		}
+	}
+}
+
+// checkError looks for failures in build reports and returns an error if any is found.
+func checkError(reports []BuildReport) error {
+	for _, report := range reports {
+		if report.BuildStatus == BuildStatusError {
+			return fmt.Errorf("one of the image build failed, see logs for more details")
+		}
+
+		if report.BuildStatus == BuildStatusError {
+			return fmt.Errorf("some tests failed, see logs for more details")
+		}
+	}
+
+	return nil
+}


### PR DESCRIPTION
Small improvement on console output to see the same kind of report we currently print for build status, but for tests.
It helps identify what went wrong with tests

```
[19:08:42][INFO] Build report
[19:08:42][INFO] 	[golang17-ci]: SUCCESS
[19:08:42][INFO] 	[golang17-goreleaser]: SUCCESS
[19:08:42][INFO] Tests report
[19:08:42][INFO] 	[golang17-ci]: PASSED
[19:08:42][INFO] 	[golang17-goreleaser]: PASSED
[19:08:42][INFO] Build process completed
```