### PR TITLE
fix(kubernetes): Send error when pod was unexpectedly deleted

### DIFF
--- a/kubernetes/pod.go
+++ b/kubernetes/pod.go
@@ -47,6 +47,13 @@ func WaitPodReady(ctx context.Context, watcher watch.Interface) (readyChan chan 
 
 				logrus.Debugf("Pod %s/%s %s, status %s", pod.ObjectMeta.Namespace,
 					pod.ObjectMeta.Name, event.Type, pod.Status.Phase)
+
+				if event.Type == watch.Deleted {
+					logrus.Errorf("Pod %s/%s was deleted", pod.ObjectMeta.Namespace, pod.ObjectMeta.Name)
+					errChan <- fmt.Errorf("pod %s was deleted", pod.ObjectMeta.Name)
+					return
+				}
+
 				switch pod.Status.Phase { //nolint: exhaustive
 				case corev1.PodRunning:
 					if running {


### PR DESCRIPTION
When building using the kuberentes executor, if the pod gets evicted for some reason, the watcher keeps watching until we reach the timeout (1h).

This PR fixes that by adding a check on the event type, and now sends an error as soon as we detect the pod was deleted.