### PR TITLE
feat(goss): detect user shell to use with docker executor

### DIFF
--- a/cmd/build.go
+++ b/cmd/build.go
@@ -352,7 +352,7 @@ func createGossTestRunner(opts buildOpts, workingDir string) (*goss.TestRunner, 
 		return goss.NewTestRunner(executor, runnerOpts), nil
 	}
 
-	return goss.NewTestRunner(&goss.DGossExecutor{}, runnerOpts), nil
+	return goss.NewTestRunner(goss.NewDGossExecutor(), runnerOpts), nil
 }
 
 func createGossKubernetesExecutor(cfg gossConfig) (*goss.KubernetesExecutor, error) {

--- a/dib/plan.go
+++ b/dib/plan.go
@@ -160,8 +160,8 @@ func checkAlreadyBuilt(graph *dag.DAG, currentTagExistsMap *sync.Map, newTag str
 
 // checkNeedsRetag iterates over the graph to find out which images need
 // to be tagged with the new tag from the latest version.
-func checkNeedsRetag(graph *dag.DAG, currentTagExistsMap,
-	previousTagExistsMap *sync.Map, oldTag string, newTag string) error {
+func checkNeedsRetag(graph *dag.DAG, currentTagExistsMap, previousTagExistsMap *sync.Map, oldTag string, newTag string,
+) error {
 	return graph.WalkErr(func(node *dag.Node) error {
 		img := node.Image
 		if img.NeedsRebuild {

--- a/goss/executor_dgoss.go
+++ b/goss/executor_dgoss.go
@@ -11,8 +11,24 @@ import (
 	"github.com/radiofrance/dib/types"
 )
 
+const defaultShell = "/bin/bash"
+
 // DGossExecutor executes goss tests using the dgoss wrapper script.
-type DGossExecutor struct{}
+type DGossExecutor struct {
+	Shell string
+}
+
+// NewDGossExecutor creates a new instance of DGossExecutor.
+func NewDGossExecutor() *DGossExecutor {
+	shell, exists := os.LookupEnv("SHELL")
+	if !exists {
+		shell = defaultShell
+	}
+
+	return &DGossExecutor{
+		Shell: shell,
+	}
+}
 
 // Execute goss tests on the given image. goss.yaml file is expected to be present in the given path.
 func (e DGossExecutor) Execute(_ context.Context, output io.Writer, opts types.RunTestOptions, args ...string) error {
@@ -23,5 +39,5 @@ func (e DGossExecutor) Execute(_ context.Context, output io.Writer, opts types.R
 
 	cmd := fmt.Sprintf("dgoss run %s yes", opts.ImageReference)
 
-	return shell.ExecuteWithWriter(output, "/bin/bash", "-c", cmd)
+	return shell.ExecuteWithWriter(output, e.Shell, "-c", cmd)
 }

--- a/goss/executor_dgoss_test.go
+++ b/goss/executor_dgoss_test.go
@@ -1,0 +1,29 @@
+package goss_test
+
+import (
+	"os"
+	"testing"
+
+	"github.com/radiofrance/dib/goss"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// nolint:paralleltest
+func Test_DGossExecutor_NewDGossExecutorUsesDefaultShell(t *testing.T) {
+	err := os.Unsetenv("SHELL")
+	require.NoError(t, err)
+
+	executor := goss.NewDGossExecutor()
+
+	assert.Equal(t, "/bin/bash", executor.Shell)
+}
+
+// nolint:paralleltest
+func Test_DGossExecutor_NewDGossExecutorDetectsShellFromEnv(t *testing.T) {
+	t.Setenv("SHELL", "/path/to/shell")
+
+	executor := goss.NewDGossExecutor()
+
+	assert.Equal(t, "/path/to/shell", executor.Shell)
+}

--- a/goss/executor_kubernetes.go
+++ b/goss/executor_kubernetes.go
@@ -28,7 +28,6 @@ type PodConfig struct {
 	// Advanced customisations (raw YAML overrides)
 	ContainerOverride string // YAML string to override the test container object.
 	PodOverride       string // YAML string to override the pod object.
-
 }
 
 // KubernetesExecutor will run goss tests in a Kubernetes cluster.

--- a/version/git.go
+++ b/version/git.go
@@ -22,7 +22,8 @@ var ErrNoPreviousBuild = errors.New("no previous build was found in git history"
 // The last version is the git revision hash of the .docker-version file.
 // It returns the hash of the compared revision, and the list of modified files.
 func GetDiffSinceLastDockerVersionChange(repositoryPath string, exec exec.Executor,
-	registry types.DockerRegistry, dockerVersionFile, referentialImage string) (string, []string, error) {
+	registry types.DockerRegistry, dockerVersionFile, referentialImage string,
+) (string, []string, error) {
 	repo, err := git.PlainOpen(repositoryPath)
 	if err != nil {
 		return "", nil, err
@@ -73,9 +74,9 @@ func GetDiffSinceLastDockerVersionChange(repositoryPath string, exec exec.Execut
 	return strings.TrimSuffix(dockerVersionContent, "\n"), fullPathDiffs, nil
 }
 
-func getDockerVersionContentForHash(repo *git.Repository, lastChangedDockerVersionHash plumbing.Hash,
-	dockerVersionFile string) (string, error) {
-	commitObject, err := repo.CommitObject(lastChangedDockerVersionHash)
+func getDockerVersionContentForHash(repo *git.Repository, lastChangedHash plumbing.Hash, dockerVersionFile string,
+) (string, error) {
+	commitObject, err := repo.CommitObject(lastChangedHash)
 	if err != nil {
 		return "", err
 	}
@@ -95,7 +96,8 @@ func getDockerVersionContentForHash(repo *git.Repository, lastChangedDockerVersi
 }
 
 func getLastChangedDockerVersion(repository *git.Repository, registry types.DockerRegistry,
-	dockerVersionFile, referentialImage string) (plumbing.Hash, error) {
+	dockerVersionFile, referentialImage string,
+) (plumbing.Hash, error) {
 	commitLog, err := repository.Log(&git.LogOptions{
 		PathFilter: func(p string) bool {
 			return p == dockerVersionFile


### PR DESCRIPTION
The default shell was hardcoded, so `dib build --local-only` command failed to run tests on MacOS.

This PR will allow `dib` to autodetect the user shell from the `SHELL` environment variable