### PR TITLE
feat(build): improve UX when testing builds locally

### DIFF
--- a/cmd/graph.go
+++ b/cmd/graph.go
@@ -82,7 +82,7 @@ func doGraph(opts rootOpts) error {
 	DAG := dib.GenerateDAG(path.Join(workingDir, opts.BuildPath), opts.RegistryURL)
 	logrus.Debug("Generate DAG -- Done")
 
-	err = dib.Plan(DAG, gcrRegistry, diffs, previousVersion, currentVersion, false, false)
+	err = dib.Plan(DAG, gcrRegistry, diffs, previousVersion, currentVersion, true, false, false)
 	if err != nil {
 		return err
 	}

--- a/dag/image.go
+++ b/dag/image.go
@@ -8,17 +8,19 @@ import (
 
 // Image holds the docker image information.
 type Image struct {
-	Name                 string
-	ShortName            string
-	Dockerfile           *dockerfile.Dockerfile
-	IgnorePatterns       []string
-	NeedsRebuild         bool
-	NeedsTests           bool
-	NeedsRetag           bool
-	RetagDone            bool
-	TagWithExtraTagsDone bool
-	RebuildDone          bool
-	RebuildFailed        bool
+	Name           string
+	ShortName      string
+	CurrentTag     string   // Current tag expected to be present on the registry before the build.
+	TargetTag      string   // New tag, not present in registry until the image is built and pushed.
+	ExtraTags      []string // A list of tags to make in addition to TargetTag.
+	Dockerfile     *dockerfile.Dockerfile
+	IgnorePatterns []string
+	NeedsRebuild   bool
+	NeedsTests     bool
+	NeedsRetag     bool
+	RetagDone      bool
+	RebuildDone    bool
+	RebuildFailed  bool
 }
 
 // DockerRef returns the fully-qualified docker ref for a given version.

--- a/dib/build_test.go
+++ b/dib/build_test.go
@@ -25,7 +25,7 @@ func Test_Rebuild_NothingToDo(t *testing.T) {
 	reportChan := make(chan dib.BuildReport, 1)
 	wg := sync.WaitGroup{}
 	wg.Add(1)
-	dib.RebuildNode(node, builder, testRunners, mock.RateLimiter{}, "new-123", false, &wg, reportChan)
+	dib.RebuildNode(node, builder, testRunners, mock.RateLimiter{}, false, &wg, reportChan)
 	wg.Wait()
 	close(reportChan)
 
@@ -50,7 +50,7 @@ func Test_Rebuild_BuildAndTest(t *testing.T) {
 	reportChan := make(chan dib.BuildReport, 1)
 	wg := sync.WaitGroup{}
 	wg.Add(1)
-	dib.RebuildNode(node, builder, testRunners, mock.RateLimiter{}, "new-123", false, &wg, reportChan)
+	dib.RebuildNode(node, builder, testRunners, mock.RateLimiter{}, false, &wg, reportChan)
 	wg.Wait()
 	close(reportChan)
 
@@ -75,7 +75,7 @@ func Test_Rebuild_TestOnly(t *testing.T) {
 	reportChan := make(chan dib.BuildReport, 1)
 	wg := sync.WaitGroup{}
 	wg.Add(1)
-	dib.RebuildNode(node, builder, testRunners, mock.RateLimiter{}, "new-123", false, &wg, reportChan)
+	dib.RebuildNode(node, builder, testRunners, mock.RateLimiter{}, false, &wg, reportChan)
 	wg.Wait()
 	close(reportChan)
 
@@ -103,7 +103,7 @@ func Test_Rebuild_TestNotSupported(t *testing.T) {
 	reportChan := make(chan dib.BuildReport, 1)
 	wg := sync.WaitGroup{}
 	wg.Add(1)
-	dib.RebuildNode(node, builder, testRunners, mock.RateLimiter{}, "new-123", false, &wg, reportChan)
+	dib.RebuildNode(node, builder, testRunners, mock.RateLimiter{}, false, &wg, reportChan)
 	wg.Wait()
 	close(reportChan)
 
@@ -132,7 +132,7 @@ func Test_Rebuild_TestError(t *testing.T) {
 	reportChan := make(chan dib.BuildReport, 1)
 	wg := sync.WaitGroup{}
 	wg.Add(1)
-	dib.RebuildNode(node, builder, testRunners, mock.RateLimiter{}, "new-123", false, &wg, reportChan)
+	dib.RebuildNode(node, builder, testRunners, mock.RateLimiter{}, false, &wg, reportChan)
 	wg.Wait()
 	close(reportChan)
 

--- a/dib/tag.go
+++ b/dib/tag.go
@@ -1,15 +1,13 @@
 package dib
 
 import (
-	"strings"
-
 	"github.com/radiofrance/dib/dag"
 	"github.com/radiofrance/dib/types"
 	"github.com/sirupsen/logrus"
 )
 
 // Retag iterates over the graph to retag each image with the given tag.
-func Retag(graph *dag.DAG, tagger types.ImageTagger, oldTag string, newTag string) error {
+func Retag(graph *dag.DAG, tagger types.ImageTagger) error {
 	return graph.WalkAsyncErr(func(node *dag.Node) error {
 		img := node.Image
 		if !img.NeedsRetag {
@@ -18,42 +16,23 @@ func Retag(graph *dag.DAG, tagger types.ImageTagger, oldTag string, newTag strin
 		if img.RetagDone {
 			return nil
 		}
-		logrus.Debugf("Retag image %s with version %s", img.Name, newTag)
-		if err := tagger.Tag(img.DockerRef(oldTag), img.DockerRef(newTag)); err != nil {
+		src := img.DockerRef(img.CurrentTag)
+		dest := img.DockerRef(img.TargetTag)
+		logrus.Debugf("Tagging \"%s\" from \"%s\"", dest, src)
+		if err := tagger.Tag(src, dest); err != nil {
 			return err
 		}
-		img.RetagDone = true
-		return nil
-	})
-}
 
-// TagWithExtraTags iterates over the graph to retag each image with the tags defined in dib.extra-tags LABEL.
-func TagWithExtraTags(graph *dag.DAG, tagger types.ImageTagger, tag string) error {
-	return graph.WalkAsyncErr(func(node *dag.Node) error {
-		img := node.Image
-		if img.TagWithExtraTagsDone {
-			return nil
-		}
-		defer func() {
-			img.TagWithExtraTagsDone = true
-		}()
-
-		if img.Dockerfile == nil || img.Dockerfile.Labels == nil {
-			return nil
-		}
-
-		extraTags, hasLabel := img.Dockerfile.Labels["dib.extra-tags"]
-		if !hasLabel {
-			return nil
-		}
-
-		for _, extraTag := range strings.Split(extraTags, ",") {
-			logrus.Debugf("Add tag %s to image %s:%s", extraTag, img.Name, tag)
-			if err := tagger.Tag(img.DockerRef(tag), img.DockerRef(extraTag)); err != nil {
+		src = img.DockerRef(img.TargetTag)
+		for _, tag := range img.ExtraTags {
+			dest = img.DockerRef(tag)
+			logrus.Debugf("Tagging \"%s\" from \"%s\"", dest, src)
+			if err := tagger.Tag(src, dest); err != nil {
 				return err
 			}
 		}
 
+		img.RetagDone = true
 		return nil
 	})
 }

--- a/dib/tag_test.go
+++ b/dib/tag_test.go
@@ -3,14 +3,11 @@ package dib_test
 import (
 	"testing"
 
-	"github.com/stretchr/testify/require"
-
-	"github.com/radiofrance/dib/dockerfile"
-
 	"github.com/radiofrance/dib/dag"
 	"github.com/radiofrance/dib/dib"
 	"github.com/radiofrance/dib/mock"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func Test_Retag_DoesNotRetagIfNoRetagNeeded(t *testing.T) {
@@ -25,7 +22,7 @@ func Test_Retag_DoesNotRetagIfNoRetagNeeded(t *testing.T) {
 	}))
 
 	tagger := &mock.Tagger{}
-	err := dib.Retag(DAG, tagger, "old", "new")
+	err := dib.Retag(DAG, tagger)
 
 	assert.NoError(t, err)
 	assert.Empty(t, tagger.RecordedCallsArgs)
@@ -38,23 +35,27 @@ func Test_Retag_DoesNotRetagIfAlreadyDone(t *testing.T) {
 	DAG.AddNode(dag.NewNode(&dag.Image{
 		Name:       "registry.example.org/image",
 		ShortName:  "image",
+		CurrentTag: "old",
+		TargetTag:  "new",
 		NeedsRetag: true,
 		RetagDone:  true,
 	}))
 
 	tagger := &mock.Tagger{}
-	err := dib.Retag(DAG, tagger, "old", "new")
+	err := dib.Retag(DAG, tagger)
 
 	assert.NoError(t, err)
 	assert.Empty(t, tagger.RecordedCallsArgs)
 }
 
-func Test_Retag_Retag(t *testing.T) {
+func Test_Retag_NoExtraLabels(t *testing.T) {
 	t.Parallel()
 
 	img := &dag.Image{
 		Name:       "registry.example.org/image",
 		ShortName:  "image",
+		CurrentTag: "old",
+		TargetTag:  "new",
 		NeedsRetag: true,
 		RetagDone:  false,
 	}
@@ -62,7 +63,7 @@ func Test_Retag_Retag(t *testing.T) {
 	DAG.AddNode(dag.NewNode(img))
 
 	tagger := &mock.Tagger{}
-	err := dib.Retag(DAG, tagger, "old", "new")
+	err := dib.Retag(DAG, tagger)
 
 	assert.NoError(t, err)
 
@@ -74,69 +75,35 @@ func Test_Retag_Retag(t *testing.T) {
 	assert.True(t, img.RetagDone)
 }
 
-func Test_TagWithExtraTags_DoesNotRetagIfAlreadyDone(t *testing.T) {
-	t.Parallel()
-
-	DAG := &dag.DAG{}
-	DAG.AddNode(dag.NewNode(&dag.Image{
-		Name:                 "registry.example.org/image",
-		ShortName:            "image",
-		TagWithExtraTagsDone: true,
-	}))
-
-	tagger := &mock.Tagger{}
-	err := dib.TagWithExtraTags(DAG, tagger, "old")
-
-	assert.NoError(t, err)
-	assert.Empty(t, tagger.RecordedCallsArgs)
-}
-
-func Test_TagWithExtraTags_NoLabels(t *testing.T) {
+func Test_Retag_WithExtraLabels(t *testing.T) {
 	t.Parallel()
 
 	img := &dag.Image{
-		Name:                 "registry.example.org/image",
-		ShortName:            "image",
-		TagWithExtraTagsDone: false,
+		Name:       "registry.example.org/image",
+		ShortName:  "image",
+		CurrentTag: "old",
+		TargetTag:  "new",
+		ExtraTags:  []string{"latest1", "latest2"},
+		NeedsRetag: true,
+		RetagDone:  false,
 	}
 	DAG := &dag.DAG{}
 	DAG.AddNode(dag.NewNode(img))
 
 	tagger := &mock.Tagger{}
-	err := dib.TagWithExtraTags(DAG, tagger, "old")
-
-	assert.NoError(t, err)
-	assert.Len(t, tagger.RecordedCallsArgs, 0)
-	assert.True(t, img.TagWithExtraTagsDone)
-}
-
-func Test_TagWithExtraTags_WithLabels(t *testing.T) {
-	t.Parallel()
-
-	img := &dag.Image{
-		Name:                 "registry.example.org/image",
-		ShortName:            "image",
-		TagWithExtraTagsDone: false,
-		Dockerfile: &dockerfile.Dockerfile{
-			Labels: map[string]string{
-				"dib.extra-tags": "latest1,latest2",
-			},
-		},
-	}
-	DAG := &dag.DAG{}
-	DAG.AddNode(dag.NewNode(img))
-
-	tagger := &mock.Tagger{}
-	err := dib.TagWithExtraTags(DAG, tagger, "old")
+	err := dib.Retag(DAG, tagger)
 
 	assert.NoError(t, err)
 
-	require.Len(t, tagger.RecordedCallsArgs, 2)
+	require.Len(t, tagger.RecordedCallsArgs, 3)
 
 	assert.Equal(t, "registry.example.org/image:old", tagger.RecordedCallsArgs[0].Src)
-	assert.Equal(t, "registry.example.org/image:latest1", tagger.RecordedCallsArgs[0].Dest)
-	assert.Equal(t, "registry.example.org/image:old", tagger.RecordedCallsArgs[1].Src)
-	assert.Equal(t, "registry.example.org/image:latest2", tagger.RecordedCallsArgs[1].Dest)
+	assert.Equal(t, "registry.example.org/image:new", tagger.RecordedCallsArgs[0].Dest)
 
-	assert.True(t, img.TagWithExtraTagsDone)
+	assert.Equal(t, "registry.example.org/image:new", tagger.RecordedCallsArgs[1].Src)
+	assert.Equal(t, "registry.example.org/image:latest1", tagger.RecordedCallsArgs[1].Dest)
+	assert.Equal(t, "registry.example.org/image:new", tagger.RecordedCallsArgs[2].Src)
+	assert.Equal(t, "registry.example.org/image:latest2", tagger.RecordedCallsArgs[2].Dest)
+
+	assert.True(t, img.RetagDone)
 }


### PR DESCRIPTION
This PR tries to slightly improve the UX of the `dib build` command when used to test things locally. Currently even with the `--local-only` flag the command is pretty much unusable.

The improvements bring the following changes :

- Don't retag any images by default, to avoid pulling them all beforehand.
- Only retag all images with the final tag in release mode