### PR TITLE
fix(hash): hash should not depend on absolute path of files

### DIFF
--- a/dib/plan.go
+++ b/dib/plan.go
@@ -58,7 +58,7 @@ func checkNeedsRebuild(graph *dag.DAG, tagExistsMap *sync.Map) error {
 			return nil
 		}
 
-		logrus.Warnf("Ref \"%s\" is missing, image must be rebuilt", ref)
+		logrus.Infof("Ref \"%s\" is missing, image must be rebuilt", ref)
 		img.NeedsRebuild = true
 		return nil
 	})


### PR DESCRIPTION
Fix problem with different hashes being produced depending on where the docker directory is on the filesystem, or depending on which parent hash is first on the list.
