### PR TITLE
feat: Add "list" command to print list of images managed by DIB

### DIFF
--- a/cmd/list.go
+++ b/cmd/list.go
@@ -1,0 +1,62 @@
+package main
+
+import (
+	"path"
+
+	"github.com/radiofrance/dib/dib"
+	"github.com/sirupsen/logrus"
+	"github.com/spf13/cobra"
+)
+
+type listOpts struct {
+	// Root options
+	BuildPath   string `mapstructure:"build_path"`
+	RegistryURL string `mapstructure:"registry_url"`
+
+	// List specific options
+	Output string `mapstructure:"output"`
+}
+
+// listCmd represents the output command.
+var listCmd = &cobra.Command{
+	Use:   "list",
+	Short: "Print list of images managed by DIB",
+	Long:  `dib list will print a list of all Docker images managed by DIB`,
+	Run: func(cmd *cobra.Command, args []string) {
+		bindPFlagsSnakeCase(cmd.Flags())
+		opts := listOpts{}
+		hydrateOptsFromViper(&opts)
+
+		err := doList(opts)
+		if err != nil {
+			logrus.Fatalf("command \"dib list\" failed: %v", err)
+		}
+	},
+}
+
+func init() {
+	rootCmd.AddCommand(listCmd)
+
+	listCmd.Flags().StringP("output", "o", "", ""+
+		"Output format (console|go-template-file)\n"+
+		"You can provide a custom format using go-template: like this: \"-o go-template-file=...\".")
+}
+
+func doList(opts listOpts) error {
+	formatOpts, err := dib.ParseOutputOptions(opts.Output)
+	if err != nil {
+		return err
+	}
+
+	workingDir, err := getWorkingDir()
+	if err != nil {
+		return err
+	}
+
+	DAG := dib.GenerateDAG(path.Join(workingDir, opts.BuildPath), opts.RegistryURL)
+	if err = dib.GenerateList(DAG, formatOpts); err != nil {
+		return err
+	}
+
+	return nil
+}

--- a/dib/list.go
+++ b/dib/list.go
@@ -1,0 +1,111 @@
+package dib
+
+import (
+	"fmt"
+	"os"
+	"sort"
+	"strings"
+	"text/template"
+
+	"github.com/olekukonko/tablewriter"
+	"github.com/radiofrance/dib/dag"
+)
+
+const (
+	ConsoleFormat        = "console"
+	GoTemplateFileFormat = "go-template-file"
+)
+
+type FormatOpts struct {
+	Type         string
+	TemplatePath string
+}
+
+func GenerateList(graph *dag.DAG, opts FormatOpts) error {
+	imagesList := GetImagesList(graph)
+
+	switch opts.Type {
+	case ConsoleFormat:
+		renderConsoleOutput(imagesList)
+	case GoTemplateFileFormat:
+		outputTemplate, err := template.ParseFiles(opts.TemplatePath)
+		if err != nil {
+			return fmt.Errorf("failed to parse go-template file : %w", err)
+		}
+
+		err = outputTemplate.Execute(os.Stdout, imagesList)
+		if err != nil {
+			return fmt.Errorf("failed to render go-template file : %w", err)
+		}
+	}
+
+	return nil
+}
+
+// GetImagesList iterate over DAG nodes and return a slice of Image sorted by their ShortName.
+func GetImagesList(graph *dag.DAG) []dag.Image {
+	imagesList := make(map[string]dag.Image)
+	graph.Walk(func(node *dag.Node) {
+		imagesList[node.Image.ShortName] = *node.Image
+	})
+
+	// Sort Images by name
+	var sortedImagesList []dag.Image
+	for _, image := range imagesList {
+		sortedImagesList = append(sortedImagesList, image)
+	}
+
+	sort.SliceStable(sortedImagesList, func(i, j int) bool {
+		return sortedImagesList[i].ShortName < sortedImagesList[j].ShortName
+	})
+
+	return sortedImagesList
+}
+
+// ParseOutputOptions parse value of the "--output" flag and ensure they are valid.
+// Currently, we only support the "go-template-file" and "console" output.
+func ParseOutputOptions(output string) (FormatOpts, error) {
+	formatOpts := FormatOpts{}
+	if output == "" || output == ConsoleFormat {
+		formatOpts.Type = ConsoleFormat
+		return formatOpts, nil
+	}
+
+	parsed := strings.Split(output, "=")
+	switch parsed[0] {
+	case GoTemplateFileFormat:
+		if len(parsed) == 1 {
+			return formatOpts, fmt.Errorf("you need to provide a path to template file when using \"go-template-file\" options")
+		}
+		formatOpts.Type = GoTemplateFileFormat
+		formatOpts.TemplatePath = parsed[1]
+	default:
+		return formatOpts, fmt.Errorf("\"%s\" is not a valid output format", output)
+	}
+
+	return formatOpts, nil
+}
+
+// renderConsoleOutput displays the list of image in stdout as a nice table.
+func renderConsoleOutput(imagesList []dag.Image) {
+	table := tablewriter.NewWriter(os.Stdout)
+	table.SetAutoWrapText(false)
+	table.SetAutoFormatHeaders(true)
+	table.SetHeaderAlignment(tablewriter.ALIGN_LEFT)
+	table.SetAlignment(tablewriter.ALIGN_LEFT)
+	table.SetCenterSeparator("")
+	table.SetColumnSeparator("")
+	table.SetRowSeparator("")
+	table.SetHeaderLine(false)
+	table.SetBorder(false)
+	table.SetTablePadding("\t")
+
+	var data [][]string
+	for _, image := range imagesList {
+		data = append(data, []string{image.ShortName, image.Hash})
+	}
+	table.AppendBulk(data)
+
+	table.SetHeader([]string{"Name", "Hash"})
+	table.Render()
+}

--- a/dib/list_test.go
+++ b/dib/list_test.go
@@ -1,0 +1,166 @@
+package dib_test
+
+import (
+	"os"
+	"path"
+	"testing"
+
+	"github.com/radiofrance/dib/dag"
+	"github.com/radiofrance/dib/dib"
+	"github.com/stretchr/testify/assert"
+)
+
+func setupFakeDag(t *testing.T) *dag.DAG {
+	t.Helper()
+
+	rootNode := newNode("test-registry/bullseye", "floor-venus-august-venus", "docker/bullseye")
+	firstChildNode := newNode("test-registry/first", "cup-neptune-snake-thirteen", "docker/bullseye/first")
+	secondChildNode := newNode("test-registry/second", "blue-bulldog-fourteen-angel", "docker/bullseye/second")
+	duplicatedNode := newNode("test-registry/second", "blue-bulldog-fourteen-angel", "docker/bullseye/second")
+	subChildNode := newNode("test-registry/third", "lamp-delaware-nineteen-angel", "docker/bullseye/second/third")
+
+	secondChildNode.AddChild(subChildNode)
+	rootNode.AddChild(firstChildNode)
+	rootNode.AddChild(secondChildNode)
+	rootNode.AddChild(duplicatedNode)
+
+	DAG := &dag.DAG{}
+	DAG.AddNode(rootNode)
+
+	return DAG
+}
+
+func Test_GenerateList_Console(t *testing.T) {
+	t.Parallel()
+
+	DAG := setupFakeDag(t)
+	opts := dib.FormatOpts{Type: "console"}
+	err := dib.GenerateList(DAG, opts)
+
+	assert.NoError(t, err)
+}
+
+func Test_GenerateList_GoTemplateFile(t *testing.T) {
+	t.Parallel()
+
+	DAG := setupFakeDag(t)
+	cwd, err := os.Getwd()
+	if err != nil {
+		t.Fatal("Failed to get current working directory.")
+	}
+
+	tests := []struct {
+		name         string
+		outputFormat dib.FormatOpts
+		expectError  bool
+	}{
+		{
+			name:         "valid go-template-file",
+			outputFormat: dib.FormatOpts{Type: "go-template-file", TemplatePath: path.Join(cwd, "../test/example_1.yml")},
+			expectError:  false,
+		},
+		{
+			name:         "invalid path to go-template-file",
+			outputFormat: dib.FormatOpts{Type: "go-template-file", TemplatePath: path.Join(cwd, "lorem")},
+			expectError:  true,
+		},
+		{
+			name:         "invalid go-template-file (use of property that doesn't exist)",
+			outputFormat: dib.FormatOpts{Type: "go-template-file", TemplatePath: path.Join(cwd, "../test/invalid_example.yml")},
+			expectError:  true,
+		},
+	}
+
+	for _, test := range tests {
+		test := test
+
+		t.Run(test.name, func(t *testing.T) {
+			t.Parallel()
+
+			err := dib.GenerateList(DAG, test.outputFormat)
+			if test.expectError {
+				assert.Error(t, err)
+			} else {
+				assert.NoError(t, err)
+			}
+		})
+	}
+}
+
+func Test_GetImageList(t *testing.T) {
+	t.Parallel()
+
+	DAG := setupFakeDag(t)
+	actual := dib.GetImagesList(DAG)
+	expected := []dag.Image{
+		{Name: "test-registry/bullseye", ShortName: "bullseye", Hash: "floor-venus-august-venus"},
+		{Name: "test-registry/first", ShortName: "first", Hash: "cup-neptune-snake-thirteen"},
+		{Name: "test-registry/second", ShortName: "second", Hash: "blue-bulldog-fourteen-angel"},
+		{Name: "test-registry/third", ShortName: "third", Hash: "lamp-delaware-nineteen-angel"},
+	}
+
+	assert.Equal(t, 4, len(actual))
+	for index := range expected {
+		assert.Equal(t, expected[index].Name, actual[index].Name)
+		assert.Equal(t, expected[index].ShortName, actual[index].ShortName)
+		assert.Equal(t, expected[index].Hash, actual[index].Hash)
+	}
+}
+
+func Test_ParseOutputOptions(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name             string
+		given            string
+		expected         dib.FormatOpts
+		expectedErrorMsg string
+	}{
+		{
+			name:             "Format: console",
+			given:            "console",
+			expected:         dib.FormatOpts{Type: "console"},
+			expectedErrorMsg: "",
+		},
+		{
+			name:             "Format: console (default)",
+			given:            "",
+			expected:         dib.FormatOpts{Type: "console"},
+			expectedErrorMsg: "",
+		},
+		{
+			name:             "Format: go-template-file",
+			given:            "go-template-file=/tmp/output.gotemplate",
+			expected:         dib.FormatOpts{Type: "go-template-file", TemplatePath: "/tmp/output.gotemplate"},
+			expectedErrorMsg: "",
+		},
+		{
+			name:             "Format: go-template-file (invalid)",
+			given:            "go-template-file",
+			expected:         dib.FormatOpts{},
+			expectedErrorMsg: "you need to provide a path to template file when using \"go-template-file\" options",
+		},
+		{
+			name:             "Format: unsupported / invalid",
+			given:            "json",
+			expected:         dib.FormatOpts{},
+			expectedErrorMsg: "\"json\" is not a valid output format",
+		},
+	}
+
+	for _, test := range tests {
+		test := test
+
+		t.Run(test.name, func(t *testing.T) {
+			t.Parallel()
+
+			actual, err := dib.ParseOutputOptions(test.given)
+			assert.Equal(t, test.expected, actual)
+			if test.expectedErrorMsg == "" {
+				assert.NoError(t, err)
+			} else {
+				assert.ErrorContains(t, err, test.expectedErrorMsg)
+			}
+		})
+	}
+}

--- a/go.mod
+++ b/go.mod
@@ -9,6 +9,7 @@ require (
 	github.com/docker/cli v20.10.17+incompatible
 	github.com/docker/docker v20.10.17+incompatible
 	github.com/mholt/archiver/v3 v3.5.1
+	github.com/olekukonko/tablewriter v0.0.5
 	github.com/sirupsen/logrus v1.8.1
 	github.com/spf13/cobra v1.4.0
 	github.com/spf13/pflag v1.0.5
@@ -87,6 +88,7 @@ require (
 	github.com/liggitt/tabwriter v0.0.0-20181228230101-89fcab3d43de // indirect
 	github.com/magiconair/properties v1.8.6 // indirect
 	github.com/mailru/easyjson v0.7.6 // indirect
+	github.com/mattn/go-runewidth v0.0.9 // indirect
 	github.com/mitchellh/go-homedir v1.1.0 // indirect
 	github.com/mitchellh/go-wordwrap v1.0.0 // indirect
 	github.com/mitchellh/mapstructure v1.5.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -1054,6 +1054,7 @@ github.com/mattn/go-runewidth v0.0.2/go.mod h1:LwmH8dsx7+W8Uxz3IHJYH5QSwggIsqBzp
 github.com/mattn/go-runewidth v0.0.4/go.mod h1:LwmH8dsx7+W8Uxz3IHJYH5QSwggIsqBzpuz5H//U1FU=
 github.com/mattn/go-runewidth v0.0.6/go.mod h1:H031xJmbD/WCDINGzjvQ9THkh0rPKHF+m2gUSrubnMI=
 github.com/mattn/go-runewidth v0.0.7/go.mod h1:H031xJmbD/WCDINGzjvQ9THkh0rPKHF+m2gUSrubnMI=
+github.com/mattn/go-runewidth v0.0.9 h1:Lm995f3rfxdpd6TSmuVCHVb/QhupuXlYr8sCI/QdE+0=
 github.com/mattn/go-runewidth v0.0.9/go.mod h1:H031xJmbD/WCDINGzjvQ9THkh0rPKHF+m2gUSrubnMI=
 github.com/mattn/go-shellwords v1.0.3/go.mod h1:3xCvwCdWdlDJUrvuMn7Wuy9eWs4pE8vqg+NOMyg4B2o=
 github.com/mattn/go-shellwords v1.0.10/go.mod h1:EZzvwXDESEeg03EKmM+RmDnNOPKG4lLtQsUlTZDWQ8Y=
@@ -1168,6 +1169,7 @@ github.com/olekukonko/tablewriter v0.0.0-20170122224234-a0225b3f23b5/go.mod h1:v
 github.com/olekukonko/tablewriter v0.0.1/go.mod h1:vsDQFd/mU46D+Z4whnwzcISnGGzXWMclvtLoiIKAKIo=
 github.com/olekukonko/tablewriter v0.0.2/go.mod h1:rSAaSIOAGT9odnlyGlUfAJaoc5w2fSBUmeGDbRWPxyQ=
 github.com/olekukonko/tablewriter v0.0.4/go.mod h1:zq6QwlOf5SlnkVbMSr5EoBv3636FWnp+qbPhuoO21uA=
+github.com/olekukonko/tablewriter v0.0.5 h1:P2Ga83D34wi1o9J6Wh1mRuqd4mF/x/lgBS7N7AbDhec=
 github.com/olekukonko/tablewriter v0.0.5/go.mod h1:hPp6KlRPjbx+hW8ykQs1w3UBbZlj6HuIJcUGPhkA7kY=
 github.com/onsi/ginkgo v0.0.0-20151202141238-7f8ab55aaf3b/go.mod h1:lLunBs/Ym6LB5Z9jYTR76FiuTmxDTDusOGeTQH+WWjE=
 github.com/onsi/ginkgo v0.0.0-20170829012221-11459a886d9c/go.mod h1:lLunBs/Ym6LB5Z9jYTR76FiuTmxDTDusOGeTQH+WWjE=

--- a/test/example_1.yml
+++ b/test/example_1.yml
@@ -1,0 +1,6 @@
+parameters:
+  total: {{ len . }}
+  dib_managed:
+  {{- range . }}
+    {{ .ShortName }}: {{ .Hash }}
+  {{- end }}

--- a/test/example_2.yml
+++ b/test/example_2.yml
@@ -1,0 +1,8 @@
+images:
+{{- range . }}
+  {{ .ShortName }}:
+    hash: "{{ .Hash }}"
+    dockerfile: "{{ .Dockerfile.ContextPath }}/{{ .Dockerfile.Filename }}"
+    extra_tags: {{ .ExtraTags }}
+    pull_cmd: "docker pull {{ .Name }}:{{ .Hash }}"
+{{- end }}

--- a/test/invalid_example.yml
+++ b/test/invalid_example.yml
@@ -1,0 +1,4 @@
+images:
+{{- range . }}
+  - {{ .InexistingField }}
+{{- end }}


### PR DESCRIPTION
This MR introduce a new "list" command that will print a list of all Docker images managed by DIB

example (with test fixtures)
```
➜ dib list 
  NAME        HASH                               
  bullseye    floor-venus-august-venus           
  kaniko      eighteen-kitten-bakerloo-december  
  multistage  cat-sweet-seven-kansas             
  sub-image   whiskey-friend-happy-minnesota     
```

We can redirect output to file like these: `dib list > dib_images.yml`

We can also use a go-template to format the output like these:
```
cat template.yml
parameters:
  dib_managed:
  {{- range . }}
    {{ .ShortName }}: {{ .Hash }}
  {{- end }}

➜ dib list -o go-template-file=template.yml
parameters:
  dib_managed:
    bullseye: floor-venus-august-venus
    kaniko: eighteen-kitten-bakerloo-december
    multistage: cat-sweet-seven-kansas
    sub-image: whiskey-friend-happy-minnesota
```