### PR TITLE
feat: make dib-managed dockerfiles buildable without dib

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,13 +52,16 @@ For the `nginx` image, we need to extend the `gcr.io/project/debian-bullseye` im
 
 ```dockerfile
 # debian/nginx/Dockerfile
-FROM gcr.io/project/debian-bullseye:DIB_MANAGED_VERSION
+FROM gcr.io/project/debian-bullseye:latest
 LABEL name="nginx"
 ```
 
-The `DIB_MANAGED_VERSION` placeholder tells DIB it should use the latest `debian-bullseye` image built by DIB itself.
-DIB will always use the latest built image, based on the current filesystem state. If the `debian-bullseye`
+The `latest` tag is a placeholder to tell DIB it should use the latest `debian-bullseye` image built by DIB itself. DIB
+will always use the latest built image, based on the current filesystem state. If the `debian-bullseye`
 image changed, it will be rebuilt first, then `nginx` will also be rebuilt because it depends on it.
+
+Use the `--placeholder-tag` option to change the name of the placeholder tag if you want to have a distinct tag name to
+avoid confusion with the `latest` tag.
 
 ## Installation
 

--- a/cmd/build.go
+++ b/cmd/build.go
@@ -30,8 +30,9 @@ const (
 
 type buildOpts struct {
 	// Root options
-	BuildPath   string `mapstructure:"build_path"`
-	RegistryURL string `mapstructure:"registry_url"`
+	BuildPath      string `mapstructure:"build_path"`
+	RegistryURL    string `mapstructure:"registry_url"`
+	PlaceholderTag string `mapstructure:"placeholder_tag"`
 
 	// Build specific options
 	DisableGenerateGraph bool         `mapstructure:"no_graph"`
@@ -198,11 +199,11 @@ func doBuild(opts buildOpts) error {
 	}
 
 	rateLimiter := ratelimit.NewChannelRateLimiter(opts.RateLimit)
-	if err := dib.Rebuild(DAG, builder, testRunners, rateLimiter, opts.LocalOnly); err != nil {
+	if err := dib.Rebuild(DAG, builder, testRunners, rateLimiter, opts.PlaceholderTag, opts.LocalOnly); err != nil {
 		return err
 	}
 
-	err = dib.Retag(DAG, tagger, opts.Release)
+	err = dib.Retag(DAG, tagger, opts.PlaceholderTag, opts.Release)
 	if err != nil {
 		return err
 	}

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -15,6 +15,7 @@ import (
 
 const (
 	defaultRegistryURL         = "eu.gcr.io/my-test-repository"
+	defaultPlaceholderTag      = "latest"
 	defaultLogLevel            = "info"
 	defaultBuildPath           = "docker"
 	defaultGossImage           = "aelsabbahy/goss:latest"
@@ -24,9 +25,9 @@ const (
 )
 
 type rootOpts struct {
-	BuildPath        string `mapstructure:"build_path"`
-	RegistryURL      string `mapstructure:"registry_url"`
-	ReferentialImage string `mapstructure:"referential_image"`
+	BuildPath      string `mapstructure:"build_path"`
+	RegistryURL    string `mapstructure:"registry_url"`
+	PlaceholderTag string `mapstructure:"placeholder_tag"`
 }
 
 var cfgFile string
@@ -57,6 +58,10 @@ found and added to the build graph. You can provide any subdirectory if you want
 as long as it has at least one Dockerfile in it.`)
 	rootCmd.PersistentFlags().String("registry-url", defaultRegistryURL,
 		"Docker registry URL where images are stored.")
+	rootCmd.PersistentFlags().String("placeholder-tag", defaultPlaceholderTag,
+		`Tag used as placeholder in Dockerfile "from" statements, and replaced internally by dib during builds 
+to use the latest tags from parent images. In release mode, all images will be tagged with the placeholder tag, so 
+Dockerfiles are always valid (images can still be built even without using dib).`)
 	rootCmd.PersistentFlags().StringP("log-level", "l", defaultLogLevel,
 		"Log level. Can be any level supported by logrus (\"info\", \"debug\", etc...)")
 }

--- a/dib/build_test.go
+++ b/dib/build_test.go
@@ -25,7 +25,7 @@ func Test_Rebuild_NothingToDo(t *testing.T) {
 	reportChan := make(chan dib.BuildReport, 1)
 	wg := sync.WaitGroup{}
 	wg.Add(1)
-	dib.RebuildNode(node, builder, testRunners, mock.RateLimiter{}, false, &wg, reportChan)
+	dib.RebuildNode(node, builder, testRunners, mock.RateLimiter{}, "DIB_MANAGED_VERSION", false, &wg, reportChan)
 	wg.Wait()
 	close(reportChan)
 
@@ -50,7 +50,7 @@ func Test_Rebuild_BuildAndTest(t *testing.T) {
 	reportChan := make(chan dib.BuildReport, 1)
 	wg := sync.WaitGroup{}
 	wg.Add(1)
-	dib.RebuildNode(node, builder, testRunners, mock.RateLimiter{}, false, &wg, reportChan)
+	dib.RebuildNode(node, builder, testRunners, mock.RateLimiter{}, "DIB_MANAGED_VERSION", false, &wg, reportChan)
 	wg.Wait()
 	close(reportChan)
 
@@ -75,7 +75,7 @@ func Test_Rebuild_TestOnly(t *testing.T) {
 	reportChan := make(chan dib.BuildReport, 1)
 	wg := sync.WaitGroup{}
 	wg.Add(1)
-	dib.RebuildNode(node, builder, testRunners, mock.RateLimiter{}, false, &wg, reportChan)
+	dib.RebuildNode(node, builder, testRunners, mock.RateLimiter{}, "DIB_MANAGED_VERSION", false, &wg, reportChan)
 	wg.Wait()
 	close(reportChan)
 
@@ -103,7 +103,7 @@ func Test_Rebuild_TestNotSupported(t *testing.T) {
 	reportChan := make(chan dib.BuildReport, 1)
 	wg := sync.WaitGroup{}
 	wg.Add(1)
-	dib.RebuildNode(node, builder, testRunners, mock.RateLimiter{}, false, &wg, reportChan)
+	dib.RebuildNode(node, builder, testRunners, mock.RateLimiter{}, "DIB_MANAGED_VERSION", false, &wg, reportChan)
 	wg.Wait()
 	close(reportChan)
 
@@ -132,7 +132,7 @@ func Test_Rebuild_TestError(t *testing.T) {
 	reportChan := make(chan dib.BuildReport, 1)
 	wg := sync.WaitGroup{}
 	wg.Add(1)
-	dib.RebuildNode(node, builder, testRunners, mock.RateLimiter{}, false, &wg, reportChan)
+	dib.RebuildNode(node, builder, testRunners, mock.RateLimiter{}, "DIB_MANAGED_VERSION", false, &wg, reportChan)
 	wg.Wait()
 	close(reportChan)
 

--- a/dib/tag.go
+++ b/dib/tag.go
@@ -7,7 +7,7 @@ import (
 )
 
 // Retag iterates over the graph to tag all images.
-func Retag(graph *dag.DAG, tagger types.ImageTagger, release bool) error {
+func Retag(graph *dag.DAG, tagger types.ImageTagger, placeholderTag string, release bool) error {
 	return graph.WalkAsyncErr(func(node *dag.Node) error {
 		img := node.Image
 		if img.RetagDone {
@@ -24,6 +24,10 @@ func Retag(graph *dag.DAG, tagger types.ImageTagger, release bool) error {
 		}
 
 		if release {
+			if err := tagger.Tag(final, img.DockerRef(placeholderTag)); err != nil {
+				return err
+			}
+
 			for _, tag := range img.ExtraTags {
 				extra := img.DockerRef(tag)
 				logrus.Debugf("Tagging \"%s\" from \"%s\"", extra, final)


### PR DESCRIPTION
Sometimes we want to be able to build an image without using DIB (e.g. with simple `docker build` command).
This is currenlty annoying because the tag used as placeholder `DIB_MANAGED_VERSION` doesn't exist on the remote registry.

## Changes

- Tag all images with the placeholder tag in release mode
- Make the placeholder tag configurable
