### PR TITLE
feat(builder): support multiple destination tags

### DIFF
--- a/pkg/dib/build.go
+++ b/pkg/dib/build.go
@@ -155,8 +155,10 @@ func doRebuild(node *dag.Node, builder types.ImageBuilder, rateLimiter ratelimit
 	}
 
 	opts := types.ImageBuilderOpts{
-		Context:   img.Dockerfile.ContextPath,
-		Tag:       img.CurrentRef(),
+		Context: img.Dockerfile.ContextPath,
+		Tags: []string{
+			img.CurrentRef(),
+		},
 		Labels:    labels,
 		Push:      !localOnly,
 		LogOutput: fileOutput,

--- a/pkg/docker/builder_test.go
+++ b/pkg/docker/builder_test.go
@@ -1,0 +1,192 @@
+package docker_test
+
+import (
+	"errors"
+	"io"
+	"testing"
+
+	"github.com/radiofrance/dib/pkg/docker"
+	"github.com/radiofrance/dib/pkg/types"
+	"github.com/stretchr/testify/assert"
+)
+
+type fakeExecutor struct {
+	ExecutedCommands []struct {
+		Command string
+		Args    []string
+	}
+	Error error
+}
+
+func (e *fakeExecutor) Execute(name string, args ...string) (string, error) {
+	e.ExecutedCommands = append(e.ExecutedCommands, struct {
+		Command string
+		Args    []string
+	}{
+		Command: name,
+		Args:    args,
+	})
+
+	return "", e.Error
+}
+
+func (e *fakeExecutor) ExecuteStdout(name string, args ...string) error {
+	_, err := e.Execute(name, args...)
+	return err
+}
+
+func (e *fakeExecutor) ExecuteWithWriter(_ io.Writer, name string, args ...string) error {
+	_, err := e.Execute(name, args...)
+	return err
+}
+
+func (e *fakeExecutor) ExecuteWithWriters(_, _ io.Writer, name string, args ...string) error {
+	_, err := e.Execute(name, args...)
+	return err
+}
+
+func provideDefaultOptions() types.ImageBuilderOpts {
+	return types.ImageBuilderOpts{
+		Context: "/tmp/docker-context",
+		Tags: []string{
+			"gcr.io/project-id/image:version",
+			"gcr.io/project-id/image:latest",
+		},
+		BuildArgs: map[string]string{
+			"someArg": "someValue",
+		},
+		Labels: map[string]string{
+			"someLabel": "someValue",
+		},
+		Push: true,
+	}
+}
+
+func Test_Build_DryRun(t *testing.T) {
+	t.Parallel()
+
+	fakeExecutor := &fakeExecutor{}
+	builder := docker.NewImageBuilderTagger(fakeExecutor, true)
+
+	opts := provideDefaultOptions()
+
+	err := builder.Build(opts)
+	assert.NoError(t, err)
+
+	assert.Empty(t, fakeExecutor.ExecutedCommands)
+}
+
+func Test_Build_Executes(t *testing.T) {
+	t.Parallel()
+
+	fakeExecutor := &fakeExecutor{}
+	builder := docker.NewImageBuilderTagger(fakeExecutor, false)
+
+	opts := provideDefaultOptions()
+
+	err := builder.Build(opts)
+
+	assert.NoError(t, err)
+	assert.Len(t, fakeExecutor.ExecutedCommands, 3)
+
+	expectedBuildArgs := []string{
+		"build",
+		"--no-cache",
+		"--tag=gcr.io/project-id/image:version",
+		"--tag=gcr.io/project-id/image:latest",
+		"--build-arg=someArg=someValue",
+		"--label=someLabel=someValue",
+		"/tmp/docker-context",
+	}
+
+	expectedPushArgs := []string{
+		"push",
+		"gcr.io/project-id/image:version",
+	}
+
+	expectedPushLatestArgs := []string{
+		"push",
+		"gcr.io/project-id/image:latest",
+	}
+
+	assert.Equal(t, "docker", fakeExecutor.ExecutedCommands[0].Command)
+	assert.ElementsMatch(t, expectedBuildArgs, fakeExecutor.ExecutedCommands[0].Args)
+
+	assert.Equal(t, "docker", fakeExecutor.ExecutedCommands[1].Command)
+	assert.ElementsMatch(t, expectedPushArgs, fakeExecutor.ExecutedCommands[1].Args)
+	assert.Equal(t, "docker", fakeExecutor.ExecutedCommands[2].Command)
+	assert.ElementsMatch(t, expectedPushLatestArgs, fakeExecutor.ExecutedCommands[2].Args)
+}
+
+func Test_Build_ExecutesDisablesPush(t *testing.T) {
+	t.Parallel()
+
+	fakeExecutor := &fakeExecutor{}
+	builder := docker.NewImageBuilderTagger(fakeExecutor, false)
+
+	opts := provideDefaultOptions()
+	opts.Push = false
+
+	err := builder.Build(opts)
+
+	assert.NoError(t, err)
+	assert.Len(t, fakeExecutor.ExecutedCommands, 1)
+
+	expectedBuildArgs := []string{
+		"build",
+		"--no-cache",
+		"--tag=gcr.io/project-id/image:version",
+		"--tag=gcr.io/project-id/image:latest",
+		"--build-arg=someArg=someValue",
+		"--label=someLabel=someValue",
+		"/tmp/docker-context",
+	}
+
+	assert.Equal(t, "docker", fakeExecutor.ExecutedCommands[0].Command)
+	assert.ElementsMatch(t, expectedBuildArgs, fakeExecutor.ExecutedCommands[0].Args)
+}
+
+func Test_Build_FailsOnExecutorError(t *testing.T) {
+	t.Parallel()
+
+	fakeExecutor := &fakeExecutor{}
+	fakeExecutor.Error = errors.New("something wrong happened")
+	builder := docker.NewImageBuilderTagger(fakeExecutor, false)
+
+	err := builder.Build(provideDefaultOptions())
+
+	assert.EqualError(t, err, "something wrong happened")
+}
+
+func Test_Tag(t *testing.T) {
+	t.Parallel()
+
+	fakeExecutor := &fakeExecutor{}
+	tagger := docker.NewImageBuilderTagger(fakeExecutor, false)
+
+	err := tagger.Tag("registry/image:src-tag", "registry/image:dest-tag")
+
+	assert.NoError(t, err)
+	assert.Len(t, fakeExecutor.ExecutedCommands, 1)
+
+	expectedTagArgs := []string{
+		"tag",
+		"registry/image:src-tag",
+		"registry/image:dest-tag",
+	}
+
+	assert.Equal(t, "docker", fakeExecutor.ExecutedCommands[0].Command)
+	assert.Equal(t, expectedTagArgs, fakeExecutor.ExecutedCommands[0].Args)
+}
+
+func Test_Tag_DryRun(t *testing.T) {
+	t.Parallel()
+
+	fakeExecutor := &fakeExecutor{}
+	tagger := docker.NewImageBuilderTagger(fakeExecutor, true)
+
+	err := tagger.Tag("registry/image:src-tag", "registry/image:dest-tag")
+
+	assert.NoError(t, err)
+	assert.Empty(t, fakeExecutor.ExecutedCommands)
+}

--- a/pkg/kaniko/builder.go
+++ b/pkg/kaniko/builder.go
@@ -49,14 +49,21 @@ func (b Builder) Build(opts types.ImageBuilderOpts) error {
 	// More infos, on Kaniko args here: https://github.com/GoogleContainerTools/kaniko#additional-flags
 	kanikoArgs := []string{
 		"--context=" + contextPath,
-		"--destination=" + opts.Tag,
 		"--log-format=text",
 		"--snapshotMode=redo",
 		"--single-snapshot",
 	}
 
+	for _, tag := range opts.Tags {
+		kanikoArgs = append(kanikoArgs, "--destination="+tag)
+	}
+
 	for k, v := range opts.BuildArgs {
 		kanikoArgs = append(kanikoArgs, fmt.Sprintf("--build-arg=%s=%s", k, v))
+	}
+
+	for k, v := range opts.Labels {
+		kanikoArgs = append(kanikoArgs, fmt.Sprintf("--label=%s=%s", k, v))
 	}
 
 	if !opts.Push {

--- a/pkg/kaniko/builder_test.go
+++ b/pkg/kaniko/builder_test.go
@@ -29,19 +29,24 @@ type fakeContextProvider struct {
 	Error      error
 }
 
-func (p fakeContextProvider) PrepareContext(opts types.ImageBuilderOpts) (string, error) {
+func (p fakeContextProvider) PrepareContext(_ types.ImageBuilderOpts) (string, error) {
 	return p.ContextURL, p.Error
 }
 
 func provideDefaultOptions() types.ImageBuilderOpts {
 	return types.ImageBuilderOpts{
 		Context: "/tmp/kaniko-context",
-		Tag:     "gcr.io/project-id/image:version",
+		Tags: []string{
+			"gcr.io/project-id/image:version",
+			"gcr.io/project-id/image:latest",
+		},
 		BuildArgs: map[string]string{
 			"someArg": "someValue",
 		},
-		Labels: nil,
-		Push:   true,
+		Labels: map[string]string{
+			"someLabel": "someValue",
+		},
+		Push: true,
 	}
 }
 
@@ -76,10 +81,12 @@ func Test_Build_Executes(t *testing.T) {
 	expectedArgs := []string{
 		"--context=dir:///tmp/kaniko-context",
 		"--destination=gcr.io/project-id/image:version",
+		"--destination=gcr.io/project-id/image:latest",
 		"--log-format=text",
 		"--snapshotMode=redo",
 		"--single-snapshot",
 		"--build-arg=someArg=someValue",
+		"--label=someLabel=someValue",
 	}
 
 	assert.ElementsMatch(t, expectedArgs, fakeExecutor.Args)
@@ -102,10 +109,12 @@ func Test_Build_ExecutesDisablesPush(t *testing.T) {
 	expectedArgs := []string{
 		"--context=dir:///tmp/kaniko-context",
 		"--destination=gcr.io/project-id/image:version",
+		"--destination=gcr.io/project-id/image:latest",
 		"--log-format=text",
 		"--snapshotMode=redo",
 		"--single-snapshot",
 		"--build-arg=someArg=someValue",
+		"--label=someLabel=someValue",
 		"--no-push",
 	}
 

--- a/pkg/kaniko/context_remote.go
+++ b/pkg/kaniko/context_remote.go
@@ -34,7 +34,7 @@ func NewRemoteContextProvider(uploader FileUploader) *RemoteContextProvider {
 // PrepareContext is responsible for creating an archive of the build context directory
 // and uploading it to the remote location where the kaniko build pod can retrieve it later.
 func (c RemoteContextProvider) PrepareContext(opts types.ImageBuilderOpts) (string, error) {
-	tagParts := strings.Split(opts.Tag, ":")
+	tagParts := strings.Split(opts.Tags[0], ":")
 	shortName := path.Base(tagParts[0])
 	remoteDir := fmt.Sprintf("kaniko/%s", shortName)
 	filename := fmt.Sprintf("context-kaniko-%s-%s.tar.gz", shortName, tagParts[1])

--- a/pkg/kaniko/context_remote_test.go
+++ b/pkg/kaniko/context_remote_test.go
@@ -30,7 +30,7 @@ func (f *fakeUploader) URL(targetPath string) string {
 func provideDefaultBuildOptions() types.ImageBuilderOpts {
 	return types.ImageBuilderOpts{
 		Context: "/tmp/kaniko-context",
-		Tag:     "gcr.io/project-id/image:version",
+		Tags:    []string{"gcr.io/project-id/image:version"},
 		BuildArgs: map[string]string{
 			"someArg": "someValue",
 		},

--- a/pkg/mock/builder.go
+++ b/pkg/mock/builder.go
@@ -10,7 +10,7 @@ type Builder struct {
 }
 
 func (e *Builder) Build(opts types.ImageBuilderOpts) error {
-	e.Refs = append(e.Refs, opts.Tag)
+	e.Refs = append(e.Refs, opts.Tags...)
 	e.Contexts = append(e.Contexts, opts.Context)
 	e.CallCount++
 	return nil

--- a/pkg/types/types.go
+++ b/pkg/types/types.go
@@ -11,8 +11,8 @@ type ImageBuilder interface {
 type ImageBuilderOpts struct {
 	// Path to the build context.
 	Context string
-	// Name of the tag to build, same as passed to the '-t' flag of the docker build command.
-	Tag string
+	// Name of the tags to build, same as passed to the '-t' flag of the docker build command.
+	Tags []string
 	// Labels a key/value set of labels to add to the image.
 	Labels map[string]string
 	// BuildArgs a key/value set of build args to pass to the build command.


### PR DESCRIPTION
I need to be able to tag an image with multiple destination tags by reusing the `github.com/radiofrance/dib/pkg/kaniko` package in a downstream application.
Both Kaniko and Docker support multiple occurrences of respectively `--destination` and `-t` flag, so I added support here and slightly changed the `ImageBuilderOpts` struct to take a slice of tags.

I also added some tests and discovered (and fixed) two small bugs:
- The kaniko builder ignores the `ImageBuilderOpts.Labels`
- The docker builder ignores the `ImageBuilderOpts.BuildArgs`
