### PR TITLE
fix: Fallback to default log-level if flag is not provided

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -91,6 +91,7 @@ func initConfig() {
 		viper.AddConfigPath(workingDir)
 	}
 
+	viper.SetDefault("log_level", defaultLogLevel)
 	// Set defaults for config values that have no flag bound to them.
 	viper.SetDefault("kaniko.executor.docker.image", defaultKanikoImage)
 	viper.SetDefault("kaniko.executor.kubernetes.image", defaultKanikoImage)


### PR DESCRIPTION
Prevents errors when, for some commands, flag "log-level" is not set. So, in this cases, we fallback to defaultLogLevel (`info`)

```sh
$ go run ./cmd version
Invalid log level 
Error: not a valid logrus Level: ""
exit status 1
```