### PR TITLE
chore: Update golangci-lint config after moving to v1.50.0

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -27,3 +27,8 @@ linters:
   - golint            # Disable because they are deprecated and throw warning in logs
   - exhaustivestruct  # Disable because they are deprecated and throw warning in logs
   - ifshort           # Disable because they are deprecated and throw warning in logs
+  - dupl              # Disable because they are deprecated and throw warning in logs
+  - deadcode          # Disable because they are deprecated and throw warning in logs
+  - varcheck          # Disable because they are deprecated and throw warning in logs
+  - structcheck       # Disable because they are deprecated and throw warning in logs
+  - nosnakecase       # Disable because they are deprecated and throw warning in logs


### PR DESCRIPTION
Disable deprecated linters that throw warning in logs