### PR TITLE
refact: Use the same code to generate pod name between goss and kaniko

### DIFF
--- a/cmd/build.go
+++ b/cmd/build.go
@@ -309,6 +309,7 @@ func createGossKubernetesExecutor(cfg gossConfig) (*goss.KubernetesExecutor, err
 		return nil, fmt.Errorf("could not get kube client from context: %w", err)
 	}
 	executor := goss.NewKubernetesExecutor(*k8sClient.Config, k8sClient.ClientSet, k8sutils.PodConfig{
+		NameGenerator:     k8sutils.UniquePodName("goss"),
 		Namespace:         cfg.Executor.Kubernetes.Namespace,
 		Image:             cfg.Executor.Kubernetes.Image,
 		ImagePullSecrets:  cfg.Executor.Kubernetes.ImagePullSecrets,

--- a/pkg/goss/executor_kubernetes.go
+++ b/pkg/goss/executor_kubernetes.go
@@ -39,10 +39,8 @@ func (e KubernetesExecutor) Execute(ctx context.Context, output io.Writer, opts 
 ) error {
 	logrus.Infof("Testing image %s with goss kubernetes executor", opts.ImageName)
 
-	var podName string
-	if e.PodConfig.NameGenerator == nil {
-		podName = k8sutils.UniquePodName("goss-" + opts.ImageName)()
-	} else {
+	podName := e.PodConfig.Name
+	if e.PodConfig.NameGenerator != nil {
 		podName = e.PodConfig.NameGenerator()
 	}
 	containerName := "test"


### PR DESCRIPTION
We loose the image name in the goss pods for now, but I'll try to put it back later, in a more generic way