### PR TITLE
fix(report): fix html anchors not working when image name contains invalid characters

### DIFF
--- a/pkg/report/templates/build.go.html
+++ b/pkg/report/templates/build.go.html
@@ -1,25 +1,25 @@
 {{- define "title" -}}Build logs | DIB{{- end -}}
 {{- define "content" -}}
-    <h3>Builds logs</h3>
+    <h3>Build logs</h3>
     <hr>
     {{/* @TODO: Add description of the page */}}
 
     <div class="accordion accordion-flush" id="build-log-accordion">
         {{ range $imageName, $imageBuildLogs := . }}
             <div class="accordion-item">
-                <h2 class="accordion-header" id="heading-image-{{ $imageName }}">
+                <h2 class="accordion-header" id="heading-image-{{ $imageName | sanitize }}">
                     <button class="accordion-button collapsed"
                             type="button"
                             data-bs-toggle="collapse"
-                            data-bs-target="#collapse-image-{{ $imageName }}"
+                            data-bs-target="#collapse-image-{{ $imageName | sanitize }}"
                             aria-expanded="false"
-                            aria-controls="collapse-image-{{ $imageName }}">
+                            aria-controls="collapse-image-{{ $imageName | sanitize }}">
                         <span>{{ $imageName }}</span>
                     </button>
                 </h2>
-                <div id="collapse-image-{{ $imageName }}"
+                <div id="collapse-image-{{ $imageName | sanitize}}"
                      class="accordion-collapse collapse"
-                     aria-labelledby="heading-image-{{ $imageName }}"
+                     aria-labelledby="heading-image-{{ $imageName | sanitize }}"
                      data-bs-parent="#build-log-accordion">
                     <div class="accordion-body">
                         <pre><code class="language-plaintext">

--- a/pkg/report/templates/index.go.html
+++ b/pkg/report/templates/index.go.html
@@ -9,13 +9,13 @@
     <div class="accordion accordion-flush" id="report-accordion">
         {{- range .buildReport }}
             <div class="accordion-item">
-                <h2 class="accordion-header" id="heading-image-{{ .ImageName }}">
+                <h2 class="accordion-header" id="heading-image-{{ .ImageName | sanitize }}">
                     <button class="accordion-button collapsed"
                             type="button"
                             data-bs-toggle="collapse"
-                            data-bs-target="#collapse-image-{{ .ImageName }}"
+                            data-bs-target="#collapse-image-{{ .ImageName | sanitize }}"
                             aria-expanded="false"
-                            aria-controls="collapse-image-{{ .ImageName }}">
+                            aria-controls="collapse-image-{{ .ImageName | sanitize }}">
                         <span>{{ .ImageName }}&nbsp; </span>
                         {{ if and (eq .TestsStatus 1) (eq .BuildStatus 1) }}
                             <span class="d-inline-block bg-success rounded-circle p-1"></span>&nbsp;
@@ -24,31 +24,31 @@
                         {{ end }}
                     </button>
                 </h2>
-                <div id="collapse-image-{{ .ImageName }}"
+                <div id="collapse-image-{{ .ImageName | sanitize }}"
                      class="accordion-collapse collapse"
-                     aria-labelledby="heading-image-{{ .ImageName }}"
+                     aria-labelledby="heading-image-{{ .ImageName | sanitize }}"
                      data-bs-parent="#report-accordion">
                     <div class="accordion-body">
                         <div>
                             <i class="fa fa-file-text" aria-hidden="true"></i>
                             <strong>Build:</strong>
                             {{ if (eq .BuildStatus 0) }}
-                                <a href="build.html#{{ .ImageName }}" class="link-secondary">Skipped</a>
+                                <a href="build.html#{{ .ImageName | sanitize }}" class="link-secondary">Skipped</a>
                             {{ else if (eq .BuildStatus 1) }}
-                                <a href="build.html#{{ .ImageName }}" class="link-success">Success</a>
+                                <a href="build.html#{{ .ImageName | sanitize }}" class="link-success">Success</a>
                             {{ else }}
-                                <a href="build.html#{{ .ImageName }}" class="link-danger">Errored</a>
+                                <a href="build.html#{{ .ImageName | sanitize }}" class="link-danger">Errored</a>
                             {{ end }}
                         </div>
                         <div>
                             <i class="fa fa-bug" aria-hidden="true"></i>
                             <strong>Tests:</strong>
                             {{ if (eq .TestsStatus 0) }}
-                                <a href="test.html#{{ .ImageName }}" class="link-secondary">Skipped</a>
+                                <a href="test.html#{{ .ImageName | sanitize }}" class="link-secondary">Skipped</a>
                             {{ else if (eq .TestsStatus 1) }}
-                                <a href="test.html#{{ .ImageName }}" class="link-success">Success</a>
+                                <a href="test.html#{{ .ImageName | sanitize }}" class="link-success">Success</a>
                             {{ else }}
-                                <a href="test.html#{{ .ImageName }}" class="link-danger">Errored</a>
+                                <a href="test.html#{{ .ImageName | sanitize }}" class="link-danger">Errored</a>
                             {{ end }}
                         </div>
                         <div>

--- a/pkg/report/templates/test.go.html
+++ b/pkg/report/templates/test.go.html
@@ -7,19 +7,19 @@
     <div class="accordion accordion-flush" id="report-accordion">
         {{ range $imageName, $testSuite := . }}
             <div class="accordion-item">
-                <h2 class="accordion-header" id="heading-image-{{ $imageName }}">
+                <h2 class="accordion-header" id="heading-image-{{ $imageName | sanitize }}">
                     <button class="accordion-button collapsed"
                             type="button"
                             data-bs-toggle="collapse"
-                            data-bs-target="#collapse-image-{{ $imageName }}"
+                            data-bs-target="#collapse-image-{{ $imageName | sanitize }}"
                             aria-expanded="false"
-                            aria-controls="collapse-image-{{ $imageName }}">
+                            aria-controls="collapse-image-{{ $imageName | sanitize }}">
                         <span>{{ $imageName }}</span>
                     </button>
                 </h2>
-                <div id="collapse-image-{{ $imageName }}"
+                <div id="collapse-image-{{ $imageName | sanitize }}"
                      class="accordion-collapse collapse"
-                     aria-labelledby="heading-image-{{ $imageName }}"
+                     aria-labelledby="heading-image-{{ $imageName | sanitize }}"
                      data-bs-parent="#report-accordion">
                     <div class="accordion-body">
                         {{ if eq "string" (printf "%T" $testSuite) }}


### PR DESCRIPTION
Fix javascript error when image name contains dots, the `document.querySelector` call fails