### PR TITLE
fix(dockerfile): image name should not contain digest when creating dag

### DIFF
--- a/cmd/list.go
+++ b/cmd/list.go
@@ -10,8 +10,9 @@ import (
 
 type listOpts struct {
 	// Root options
-	BuildPath   string `mapstructure:"build_path"`
-	RegistryURL string `mapstructure:"registry_url"`
+	BuildPath      string `mapstructure:"build_path"`
+	RegistryURL    string `mapstructure:"registry_url"`
+	PlaceholderTag string `mapstructure:"placeholder_tag"`
 
 	// List specific options
 	Output string `mapstructure:"output"`

--- a/pkg/dib/generate_dag.go
+++ b/pkg/dib/generate_dag.go
@@ -27,7 +27,7 @@ const dockerignore = ".dockerignore"
 func GenerateDAG(buildPath string, registryPrefix string) *dag.DAG {
 	var allFiles []string
 	cache := make(map[string]*dag.Node)
-	allParents := make(map[string][]string)
+	allParents := make(map[string][]dockerfile.ImageRef)
 	err := filepath.Walk(buildPath, func(filePath string, info os.FileInfo, err error) error {
 		if err != nil {
 			return err
@@ -78,7 +78,7 @@ func GenerateDAG(buildPath string, registryPrefix string) *dag.DAG {
 	// Fill parents for each image, for simplicity of use in other functions
 	for name, parents := range allParents {
 		for _, parent := range parents {
-			if p, ok := cache[parent]; ok {
+			if p, ok := cache[parent.Name]; ok {
 				p.AddChild(cache[name])
 			}
 		}

--- a/pkg/dib/metadata.go
+++ b/pkg/dib/metadata.go
@@ -74,7 +74,8 @@ func (m ImageMetadata) WithImage(image *dag.Image) ImageMetadata {
 	}
 
 	if len(image.Dockerfile.From) > 0 {
-		m.BaseName = image.Dockerfile.From[0]
+		// The base image is in the last FROM statement
+		m.BaseName = image.Dockerfile.From[len(image.Dockerfile.From)-1].Name
 	}
 
 	return m

--- a/pkg/dib/metadata_test.go
+++ b/pkg/dib/metadata_test.go
@@ -35,7 +35,9 @@ func Test_LabelsFromGitHubMetadata(t *testing.T) { //nolint:paralleltest
 		Dockerfile: &dockerfile.Dockerfile{
 			ContextPath: path.Join(cwd, "context/subdir"),
 			Filename:    "Dockerfile",
-			From:        []string{"debian"},
+			From: []dockerfile.ImageRef{
+				{Name: "debian"},
+			},
 		},
 	}
 
@@ -77,7 +79,9 @@ func Test_LabelsFromGitLabMetadata(t *testing.T) { //nolint:paralleltest
 		Dockerfile: &dockerfile.Dockerfile{
 			ContextPath: path.Join(cwd, "context/subdir"),
 			Filename:    "Dockerfile",
-			From:        []string{"debian"},
+			From: []dockerfile.ImageRef{
+				{Name: "debian"},
+			},
 		},
 	}
 
@@ -116,7 +120,9 @@ func Test_LabelsFromGitMetadata(t *testing.T) { //nolint:paralleltest
 		Dockerfile: &dockerfile.Dockerfile{
 			ContextPath: path.Join(cwd, "../../context/subdir"),
 			Filename:    "Dockerfile",
-			From:        []string{"debian"},
+			From: []dockerfile.ImageRef{
+				{Name: "debian"},
+			},
 		},
 	}
 

--- a/pkg/dib/plan_test.go
+++ b/pkg/dib/plan_test.go
@@ -20,7 +20,9 @@ func newNode(name, hash, contextPath string) *dag.Node {
 		Dockerfile: &dockerfile.Dockerfile{
 			ContextPath: contextPath,
 			Filename:    "Dockerfile",
-			From:        []string{"debian"},
+			From: []dockerfile.ImageRef{
+				{Name: "debian"},
+			},
 			Labels: map[string]string{
 				"name":    path.Base(contextPath),
 				"version": "v1",

--- a/pkg/dockerfile/dockerfile_test.go
+++ b/pkg/dockerfile/dockerfile_test.go
@@ -1,0 +1,163 @@
+package dockerfile_test
+
+import (
+	"os"
+	"path"
+	"testing"
+
+	"github.com/radiofrance/dib/pkg/dockerfile"
+	"github.com/stretchr/testify/assert"
+)
+
+func Test(t *testing.T) {
+	t.Parallel()
+
+	tests := map[string]struct {
+		filename       string
+		expectedFrom   []dockerfile.ImageRef
+		expectedLabels map[string]string
+	}{
+		"simple dockerfile": {
+			filename: "simple.dockerfile",
+			expectedFrom: []dockerfile.ImageRef{
+				{
+					Name:   "registry.com/example",
+					Tag:    "",
+					Digest: "",
+				},
+			},
+			expectedLabels: map[string]string{
+				"name": "example",
+			},
+		},
+		"simple dockerfile with digest": {
+			filename: "simple-digest.dockerfile",
+			expectedFrom: []dockerfile.ImageRef{
+				{
+					Name:   "registry.com/example",
+					Tag:    "",
+					Digest: "sha256:d23df29669d05462cf55ce2274a3a897aa2e2655d0fad104375f8ef06164b575",
+				},
+			},
+			expectedLabels: map[string]string{
+				"name": "example",
+			},
+		},
+		"simple dockerfile with tag": {
+			filename: "simple-tag.dockerfile",
+			expectedFrom: []dockerfile.ImageRef{
+				{
+					Name:   "registry.com/example",
+					Tag:    "latest",
+					Digest: "",
+				},
+			},
+			expectedLabels: map[string]string{
+				"name": "example",
+			},
+		},
+		"simple dockerfile with tag and digest": {
+			filename: "simple-tag-digest.dockerfile",
+			expectedFrom: []dockerfile.ImageRef{
+				{
+					Name:   "registry.com/example",
+					Tag:    "latest",
+					Digest: "sha256:d23df29669d05462cf55ce2274a3a897aa2e2655d0fad104375f8ef06164b575",
+				},
+			},
+			expectedLabels: map[string]string{
+				"name": "example",
+			},
+		},
+		"multistage dockerfile": {
+			filename: "multistage.dockerfile",
+			expectedFrom: []dockerfile.ImageRef{
+				{
+					Name:   "registry.com/builder",
+					Tag:    "",
+					Digest: "",
+				},
+				{
+					Name:   "registry.com/example",
+					Tag:    "",
+					Digest: "",
+				},
+			},
+			expectedLabels: map[string]string{
+				"name": "example",
+			},
+		},
+		"multistage dockerfile with digest": {
+			filename: "multistage-digest.dockerfile",
+			expectedFrom: []dockerfile.ImageRef{
+				{
+					Name:   "registry.com/builder",
+					Tag:    "",
+					Digest: "sha256:d23df29669d05462cf55ce2274a3a897aa2e2655d0fad104375f8ef06164b575",
+				},
+				{
+					Name:   "registry.com/example",
+					Tag:    "",
+					Digest: "",
+				},
+			},
+			expectedLabels: map[string]string{
+				"name": "example",
+			},
+		},
+		"multistage dockerfile with tag": {
+			filename: "multistage-tag.dockerfile",
+			expectedFrom: []dockerfile.ImageRef{
+				{
+					Name:   "registry.com/builder",
+					Tag:    "latest",
+					Digest: "",
+				},
+				{
+					Name:   "registry.com/example",
+					Tag:    "",
+					Digest: "",
+				},
+			},
+			expectedLabels: map[string]string{
+				"name": "example",
+			},
+		},
+		"multistage dockerfile with tag and digest": {
+			filename: "multistage-tag-digest.dockerfile",
+			expectedFrom: []dockerfile.ImageRef{
+				{
+					Name:   "registry.com/builder",
+					Tag:    "latest",
+					Digest: "sha256:d23df29669d05462cf55ce2274a3a897aa2e2655d0fad104375f8ef06164b575",
+				},
+				{
+					Name:   "registry.com/example",
+					Tag:    "",
+					Digest: "",
+				},
+			},
+			expectedLabels: map[string]string{
+				"name": "example",
+			},
+		},
+	}
+	for name, test := range tests {
+		test := test
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+
+			cwd, err := os.Getwd()
+			if err != nil {
+				t.Fatal("Failed to get current working directory.")
+			}
+			fullpath := path.Join(cwd, "../../test/fixtures/dockerfile", test.filename)
+
+			result, err := dockerfile.ParseDockerfile(fullpath)
+			assert.NoError(t, err)
+
+			assert.Equal(t, test.expectedFrom, result.From)
+			assert.Equal(t, test.expectedLabels, result.Labels)
+		})
+	}
+}

--- a/test/fixtures/dockerfile/multistage-alias.dockerfile
+++ b/test/fixtures/dockerfile/multistage-alias.dockerfile
@@ -1,0 +1,4 @@
+FROM registry.com/builder as builder
+
+FROM registry.com/example
+LABEL name="example"

--- a/test/fixtures/dockerfile/multistage-digest-alias.dockerfile
+++ b/test/fixtures/dockerfile/multistage-digest-alias.dockerfile
@@ -1,0 +1,4 @@
+FROM registry.com/builder@sha256:d23df29669d05462cf55ce2274a3a897aa2e2655d0fad104375f8ef06164b575 as builder
+
+FROM registry.com/example
+LABEL name="example"

--- a/test/fixtures/dockerfile/multistage-digest.dockerfile
+++ b/test/fixtures/dockerfile/multistage-digest.dockerfile
@@ -1,0 +1,4 @@
+FROM registry.com/builder@sha256:d23df29669d05462cf55ce2274a3a897aa2e2655d0fad104375f8ef06164b575
+
+FROM registry.com/example
+LABEL name="example"

--- a/test/fixtures/dockerfile/multistage-tag-alias.dockerfile
+++ b/test/fixtures/dockerfile/multistage-tag-alias.dockerfile
@@ -1,0 +1,4 @@
+FROM registry.com/builder:latest as builder
+
+FROM registry.com/example
+LABEL name="example"

--- a/test/fixtures/dockerfile/multistage-tag-digest-alias.dockerfile
+++ b/test/fixtures/dockerfile/multistage-tag-digest-alias.dockerfile
@@ -1,0 +1,4 @@
+FROM registry.com/builder:latest@sha256:d23df29669d05462cf55ce2274a3a897aa2e2655d0fad104375f8ef06164b575 as builder
+
+FROM registry.com/example
+LABEL name="example"

--- a/test/fixtures/dockerfile/multistage-tag-digest.dockerfile
+++ b/test/fixtures/dockerfile/multistage-tag-digest.dockerfile
@@ -1,0 +1,4 @@
+FROM registry.com/builder:latest@sha256:d23df29669d05462cf55ce2274a3a897aa2e2655d0fad104375f8ef06164b575
+
+FROM registry.com/example
+LABEL name="example"

--- a/test/fixtures/dockerfile/multistage-tag.dockerfile
+++ b/test/fixtures/dockerfile/multistage-tag.dockerfile
@@ -1,0 +1,4 @@
+FROM registry.com/builder:latest
+
+FROM registry.com/example
+LABEL name="example"

--- a/test/fixtures/dockerfile/multistage.dockerfile
+++ b/test/fixtures/dockerfile/multistage.dockerfile
@@ -1,0 +1,4 @@
+FROM registry.com/builder
+
+FROM registry.com/example
+LABEL name="example"

--- a/test/fixtures/dockerfile/simple-digest.dockerfile
+++ b/test/fixtures/dockerfile/simple-digest.dockerfile
@@ -1,0 +1,2 @@
+FROM registry.com/example@sha256:d23df29669d05462cf55ce2274a3a897aa2e2655d0fad104375f8ef06164b575
+LABEL name="example"

--- a/test/fixtures/dockerfile/simple-tag-digest.dockerfile
+++ b/test/fixtures/dockerfile/simple-tag-digest.dockerfile
@@ -1,0 +1,2 @@
+FROM registry.com/example:latest@sha256:d23df29669d05462cf55ce2274a3a897aa2e2655d0fad104375f8ef06164b575
+LABEL name="example"

--- a/test/fixtures/dockerfile/simple-tag.dockerfile
+++ b/test/fixtures/dockerfile/simple-tag.dockerfile
@@ -1,0 +1,2 @@
+FROM registry.com/example:latest
+LABEL name="example"

--- a/test/fixtures/dockerfile/simple.dockerfile
+++ b/test/fixtures/dockerfile/simple.dockerfile
@@ -1,0 +1,2 @@
+FROM registry.com/example
+LABEL name="example"


### PR DESCRIPTION
The regex used when parsing the `FROM` statement must not include the digest to avoid problems.

I added some tests to ensure non-regression