### PR TITLE
chore(ci): pin golangci-lint version

### DIFF
--- a/.github/workflows/lint.golang.yml
+++ b/.github/workflows/lint.golang.yml
@@ -22,3 +22,6 @@ jobs:
       - uses: actions/checkout@8e5e7e5ab8b370d6c329ec480221332ada57f0ab # v3.5.2
 
       - uses: golangci/golangci-lint-action@08e2f20817b15149a52b5b3ebe7de50aff2ba8c5 # v3.4.0
+        with:
+          # renovate: datasource=github-releases depName=golangci/golangci-lint
+          version: v1.52.2


### PR DESCRIPTION
Pin the exact version of golangci-lint to avoid breaking changes when new releases are published