### PR TITLE
fix(dag): visit nodes only once

### DIFF
--- a/pkg/dag/dag_test.go
+++ b/pkg/dag/dag_test.go
@@ -66,6 +66,42 @@ func Test_Walk_RunsAllNodes(t *testing.T) {
 	assert.Len(t, tracking, 6)
 }
 
+func Test_Walk_RunsAllNodesOnlyOnce(t *testing.T) {
+	t.Parallel()
+
+	visits := make(map[*dag.Node]int)
+
+	root1 := &dag.Node{}
+	root2 := &dag.Node{}
+
+	child1 := &dag.Node{}
+	root1.AddChild(child1)
+	child2 := &dag.Node{}
+	root1.AddChild(child2)
+	root2.AddChild(child2)
+
+	DAG := dag.DAG{}
+	DAG.AddNode(root1)
+	DAG.AddNode(root2)
+
+	DAG.Walk(func(node *dag.Node) {
+		_, ok := visits[node]
+		if !ok {
+			visits[node] = 0
+		}
+
+		visits[node]++
+	})
+
+	// Assert that the visitor func ran on every node.
+	assert.Len(t, visits, 4) // The DAG has exactly 4 nodes.
+
+	// Assert that the visitor func ran once per node.
+	for _, visits := range visits {
+		assert.Equal(t, 1, visits)
+	}
+}
+
 func Test_WalkErr_RunsAllNodesWhenNoError(t *testing.T) {
 	t.Parallel()
 

--- a/pkg/dag/node.go
+++ b/pkg/dag/node.go
@@ -46,23 +46,23 @@ func (n *Node) Parents() []*Node {
 	return n.parents
 }
 
-// Walk applies the visitor func to the current node, then to every children nodes, recursively.
-func (n *Node) Walk(visitor NodeVisitorFunc) {
+// walk applies the visitor func to the current node, then to every children nodes, recursively.
+func (n *Node) walk(visitor NodeVisitorFunc) {
 	visitor(n)
 	for _, childNode := range n.children {
-		childNode.Walk(visitor)
+		childNode.walk(visitor)
 	}
 }
 
-// WalkErr applies the visitor func to the current node, then to every children nodes, recursively.
+// walkErr applies the visitor func to the current node, then to every children nodes, recursively.
 // If an error occurs, it stops traversing the graph and returns the error immediately.
-func (n *Node) WalkErr(visitor NodeVisitorFuncErr) error {
+func (n *Node) walkErr(visitor NodeVisitorFuncErr) error {
 	err := visitor(n)
 	if err != nil {
 		return err
 	}
 	for _, childNode := range n.children {
-		err = childNode.WalkErr(visitor)
+		err = childNode.walkErr(visitor)
 		if err != nil {
 			return err
 		}
@@ -70,9 +70,9 @@ func (n *Node) WalkErr(visitor NodeVisitorFuncErr) error {
 	return nil
 }
 
-// WalkAsyncErr applies the visitor func to the current node, then to every children nodes, asynchronously.
+// walkAsyncErr applies the visitor func to the current node, then to every children nodes, asynchronously.
 // If an error occurs, it stops traversing the graph and returns the error immediately.
-func (n *Node) WalkAsyncErr(visitor NodeVisitorFuncErr) error {
+func (n *Node) walkAsyncErr(visitor NodeVisitorFuncErr) error {
 	errG := new(errgroup.Group)
 	errG.Go(func() error {
 		return visitor(n)
@@ -80,17 +80,17 @@ func (n *Node) WalkAsyncErr(visitor NodeVisitorFuncErr) error {
 	for _, childNode := range n.children {
 		childNode := childNode
 		errG.Go(func() error {
-			return childNode.WalkAsyncErr(visitor)
+			return childNode.walkAsyncErr(visitor)
 		})
 	}
 	return errG.Wait()
 }
 
-// WalkInDepth makes a depth-first recursive walk through the graph.
+// walkInDepth makes a depth-first recursive walk through the graph.
 // It applies the visitor func to every children node, then to the current node itself.
-func (n *Node) WalkInDepth(visitor NodeVisitorFunc) {
+func (n *Node) walkInDepth(visitor NodeVisitorFunc) {
 	for _, childNode := range n.children {
-		childNode.WalkInDepth(visitor)
+		childNode.walkInDepth(visitor)
 	}
 	visitor(n)
 }

--- a/pkg/dib/generate_dag.go
+++ b/pkg/dib/generate_dag.go
@@ -78,9 +78,24 @@ func GenerateDAG(buildPath string, registryPrefix string) *dag.DAG {
 	// Fill parents for each image, for simplicity of use in other functions
 	for name, parents := range allParents {
 		for _, parent := range parents {
-			if p, ok := cache[parent.Name]; ok {
-				p.AddChild(cache[name])
+			node, ok := cache[parent.Name]
+			if !ok {
+				continue
 			}
+
+			// Check that children does not already exist to avoid duplicates.
+			childAlreadyExists := false
+			for _, child := range node.Children() {
+				if child.Image.Name == name {
+					childAlreadyExists = true
+				}
+			}
+
+			if childAlreadyExists {
+				continue
+			}
+
+			node.AddChild(cache[name])
 		}
 	}
 

--- a/pkg/dib/generate_dag_test.go
+++ b/pkg/dib/generate_dag_test.go
@@ -30,6 +30,8 @@ func Test_GenerateDAG(t *testing.T) {
 
 	multistageNode, exists := nodes["multistage"]
 	require.True(t, exists)
+
+	assert.Len(t, multistageNode.Parents(), 1)
 	assert.Equal(t, []string{"latest"}, multistageNode.Image.ExtraTags)
 }
 
@@ -157,6 +159,7 @@ LABEL version="v1"
 FROM eu.gcr.io/my-test-repository/bullseye:v1 as builder
 FROM eu.gcr.io/my-test-repository/node:v1
 
+FROM eu.gcr.io/my-test-repository/bullseye:v1
 LABEL name="multistage"
 LABEL dib.extra-tags="latest"
 		`),


### PR DESCRIPTION
When nodes have more than one parent, the `dag.Walk*()` functions visit the node `n` times, with `n` the number of direct parent nodes. This behaviour is not expected and may cause bugs in the future. This change fixes that by ensuring a node can only be visited once.