### PR TITLE
feat: Add support for build arguments to build command

### DIFF
--- a/cmd/build.go
+++ b/cmd/build.go
@@ -51,11 +51,11 @@ Otherwise, dib will create a new tag based on the previous tag.`,
 		for _, arg := range opts.BuildArg {
 			key, val, hasVal := strings.Cut(arg, "=")
 			if hasVal {
-				buildArgs[key] = val
+				buildArgs[key] = os.ExpandEnv(val)
 			} else {
 				// check if the env is set in the local environment and use that value if it is
 				if val, present := os.LookupEnv(key); present {
-					buildArgs[key] = val
+					buildArgs[key] = os.ExpandEnv(val)
 				} else {
 					delete(buildArgs, key)
 				}

--- a/cmd/list.go
+++ b/cmd/list.go
@@ -46,7 +46,7 @@ func doList(opts dib.ListOpts) error {
 	}
 
 	buildPath := path.Join(workingDir, opts.BuildPath)
-	graph, err := dib.GenerateDAG(buildPath, opts.RegistryURL, opts.HashListFilePath)
+	graph, err := dib.GenerateDAG(buildPath, opts.RegistryURL, opts.HashListFilePath, map[string]string{})
 	if err != nil {
 		return fmt.Errorf("cannot generate DAG: %w", err)
 	}

--- a/cmd/list.go
+++ b/cmd/list.go
@@ -2,7 +2,9 @@ package main
 
 import (
 	"fmt"
+	"os"
 	"path"
+	"strings"
 
 	"github.com/radiofrance/dib/internal/logger"
 	"github.com/radiofrance/dib/pkg/dib"
@@ -32,6 +34,8 @@ func init() {
 	listCmd.Flags().StringP("output", "o", "", ""+
 		"Output format (console|go-template-file)\n"+
 		"You can provide a custom format using go-template: like this: \"-o go-template-file=...\".")
+	listCmd.Flags().StringArray("build-arg", []string{},
+		"`argument=value` to supply to the builder")
 }
 
 func doList(opts dib.ListOpts) error {
@@ -45,8 +49,23 @@ func doList(opts dib.ListOpts) error {
 		return err
 	}
 
+	buildArgs := map[string]string{}
+	for _, arg := range opts.BuildArg {
+		key, val, hasVal := strings.Cut(arg, "=")
+		if hasVal {
+			buildArgs[key] = os.ExpandEnv(val)
+		} else {
+			// check if the env is set in the local environment and use that value if it is
+			if val, present := os.LookupEnv(key); present {
+				buildArgs[key] = os.ExpandEnv(val)
+			} else {
+				delete(buildArgs, key)
+			}
+		}
+	}
+
 	buildPath := path.Join(workingDir, opts.BuildPath)
-	graph, err := dib.GenerateDAG(buildPath, opts.RegistryURL, opts.HashListFilePath, map[string]string{})
+	graph, err := dib.GenerateDAG(buildPath, opts.RegistryURL, opts.HashListFilePath, buildArgs)
 	if err != nil {
 		return fmt.Errorf("cannot generate DAG: %w", err)
 	}

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -10,7 +10,7 @@ default values in the configuration file, and then override with environment var
 
 Example:
 ```shell
-dib build --registry-url=gcr.io/project --build-arg=foo=bar
+dib build --registry-url=gcr.io/project
 ```
 
 ### Environment variables

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -10,7 +10,7 @@ default values in the configuration file, and then override with environment var
 
 Example:
 ```shell
-dib build --registry-url=gcr.io/project
+dib build --registry-url=gcr.io/project --build-arg=foo=bar
 ```
 
 ### Environment variables

--- a/docs/examples/config/reference.yaml
+++ b/docs/examples/config/reference.yaml
@@ -1,5 +1,5 @@
 ---
-# Log level: "trace", "debug", "info", "warning", "error", "fatal", "panic". Defaults to "info".
+# Log level: "debug", "info", "warning", "error", "fatal". Defaults to "info".
 log_level: info
 
 # URL of the registry where the images should be stored.
@@ -17,6 +17,11 @@ placeholder_tag: latest
 # The rate limit can be increased to allow parallel builds. This dramatically reduces the build times
 # when using the Kubernetes executor as build pods are scheduled across multiple nodes.
 rate_limit: 1
+
+# Use build arguments to set build-time variables. The format is a list of strings.
+build_arg:
+  - FOO1="bar1"
+  - FOO2="bar2"
 
 # Path to the directory where the reports are generated. The directory will be created if it doesn't exist.
 reports_dir: reports

--- a/docs/examples/config/reference.yaml
+++ b/docs/examples/config/reference.yaml
@@ -18,10 +18,11 @@ placeholder_tag: latest
 # when using the Kubernetes executor as build pods are scheduled across multiple nodes.
 rate_limit: 1
 
-# Use build arguments to set build-time variables. The format is a list of strings.
+# Use build arguments to set build-time variables. The format is a list of strings. Env vars are expanded.
 build_arg:
   - FOO1="bar1"
-  - FOO2="bar2"
+  - FOO2=$BAR
+  - FOO3=${BAR}
 
 # Path to the directory where the reports are generated. The directory will be created if it doesn't exist.
 reports_dir: reports

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -6,7 +6,7 @@ Roadmap
 DIB is still a work in progress, but we plan to release a stable version (v1.0.0) after we have added the 
 following features:
 
-- **Per-image configuration:** Some images may require additional build args, or have their own tagging scheme. Being 
+- **Per-image configuration:** Some images may require their own tagging scheme. Being 
     able to configure those settings for each image is necessary.
 
 

--- a/internal/logger/logger.go
+++ b/internal/logger/logger.go
@@ -56,7 +56,6 @@ func SetLevel(level *string) {
 
 	switch *level {
 	case "debug":
-		Infof("debug mode enabled")
 		log.Level = LogLevelDebug
 	case "info":
 		log.Level = LogLevelInfo
@@ -71,6 +70,7 @@ func SetLevel(level *string) {
 	}
 
 	logger.Store(log)
+	Infof("Log level set to %s", log.Level)
 }
 
 // LogLevelStyle returns the style of the prefix for each log level.

--- a/pkg/dag/image_test.go
+++ b/pkg/dag/image_test.go
@@ -76,6 +76,7 @@ func Test_Print(t *testing.T) {
 		"          tag: \"3.17\"\n" +
 		"          digest: 9ed4aefc74f6792b5a804d1d146fe4b4a2299147b0f50eaf2b08435d7b38c27e\n" +
 		"    labels:\n" +
-		"        dib.extra-tags: \"3.17\"\n"
+		"        dib.extra-tags: \"3.17\"\n" +
+		"    args: {}\n"
 	assert.Equal(t, expected, image.Print())
 }

--- a/pkg/dib/build_test.go
+++ b/pkg/dib/build_test.go
@@ -205,7 +205,7 @@ func TestRebuildGraph(t *testing.T) {
 				},
 			}
 
-			res := dibBuilder.RebuildGraph(builder, mock.RateLimiter{})
+			res := dibBuilder.RebuildGraph(builder, mock.RateLimiter{}, map[string]string{})
 
 			assert.Len(t, res.BuildReports, len(test.expBuildReports))
 			for i, buildReport := range res.BuildReports {

--- a/pkg/dib/generate_dag_test.go
+++ b/pkg/dib/generate_dag_test.go
@@ -18,7 +18,7 @@ const fixtureDir = "../../test/fixtures/docker"
 func TestGenerateDAG(t *testing.T) {
 	t.Run("basic tests", func(t *testing.T) {
 		graph, err := dib.GenerateDAG(fixtureDir,
-			"eu.gcr.io/my-test-repository", "")
+			"eu.gcr.io/my-test-repository", "", map[string]string{})
 		require.NoError(t, err)
 
 		nodes := flattenNodes(graph)
@@ -40,7 +40,7 @@ func TestGenerateDAG(t *testing.T) {
 		tmpDir := copyFixtures(t)
 
 		graph0, err := dib.GenerateDAG(tmpDir,
-			"eu.gcr.io/my-test-repository", "")
+			"eu.gcr.io/my-test-repository", "", map[string]string{})
 		require.NoError(t, err)
 
 		nodes0 := flattenNodes(graph0)
@@ -56,7 +56,7 @@ func TestGenerateDAG(t *testing.T) {
 
 		// Then ONLY the hash of the child node bullseye/multistage should have changed
 		graph1, err := dib.GenerateDAG(tmpDir,
-			"eu.gcr.io/my-test-repository", "")
+			"eu.gcr.io/my-test-repository", "", map[string]string{})
 		require.NoError(t, err)
 
 		nodes1 := flattenNodes(graph1)
@@ -73,7 +73,7 @@ func TestGenerateDAG(t *testing.T) {
 		tmpDir := copyFixtures(t)
 
 		graph0, err := dib.GenerateDAG(tmpDir,
-			"eu.gcr.io/my-test-repository", "")
+			"eu.gcr.io/my-test-repository", "", map[string]string{})
 		require.NoError(t, err)
 
 		nodes0 := flattenNodes(graph0)
@@ -89,7 +89,7 @@ func TestGenerateDAG(t *testing.T) {
 
 		// Then ONLY the hash of the child node bullseye/multistage should have changed
 		graph1, err := dib.GenerateDAG(tmpDir,
-			"eu.gcr.io/my-test-repository", "")
+			"eu.gcr.io/my-test-repository", "", map[string]string{})
 		require.NoError(t, err)
 
 		nodes1 := flattenNodes(graph1)
@@ -104,12 +104,13 @@ func TestGenerateDAG(t *testing.T) {
 
 	t.Run("using custom hash list should change only hashes of nodes with custom label", func(t *testing.T) {
 		graph0, err := dib.GenerateDAG(fixtureDir,
-			"eu.gcr.io/my-test-repository", "")
+			"eu.gcr.io/my-test-repository", "", map[string]string{})
 		require.NoError(t, err)
 
 		graph1, err := dib.GenerateDAG(fixtureDir,
 			"eu.gcr.io/my-test-repository",
-			"../../test/fixtures/dib/valid_wordlist.txt")
+			"../../test/fixtures/dib/valid_wordlist.txt",
+			map[string]string{})
 		require.NoError(t, err)
 
 		nodes0 := flattenNodes(graph0)
@@ -120,8 +121,29 @@ func TestGenerateDAG(t *testing.T) {
 		subNode1 := nodes1["sub-image"]
 
 		assert.Equal(t, rootNode1.Image.Hash, rootNode0.Image.Hash)
-		assert.Equal(t, "berlin-undress-hydrogen-april", subNode0.Image.Hash)
-		assert.Equal(t, "archeops-glaceon-chinchou-aipom", subNode1.Image.Hash)
+		assert.Equal(t, "violet-minnesota-alabama-alpha", subNode0.Image.Hash)
+		assert.Equal(t, "golduck-dialga-abra-aegislash", subNode1.Image.Hash)
+	})
+
+	t.Run("using arg used in root node should change all hashes", func(t *testing.T) {
+		graph0, err := dib.GenerateDAG(fixtureDir,
+			"eu.gcr.io/my-test-repository", "",
+			map[string]string{})
+		require.NoError(t, err)
+
+		graph1, err := dib.GenerateDAG(fixtureDir,
+			"eu.gcr.io/my-test-repository", "",
+			map[string]string{
+				"HELLO": "world",
+			})
+		require.NoError(t, err)
+
+		nodes0 := flattenNodes(graph0)
+		rootNode0 := nodes0["bullseye"]
+		nodes1 := flattenNodes(graph1)
+		rootNode1 := nodes1["bullseye"]
+
+		assert.NotEqual(t, rootNode1.Image.Hash, rootNode0.Image.Hash)
 	})
 }
 

--- a/pkg/dib/list.go
+++ b/pkg/dib/list.go
@@ -117,5 +117,6 @@ type ListOpts struct {
 	HashListFilePath string `mapstructure:"hash_list_file_path"`
 
 	// List specific options
-	Output string `mapstructure:"output"`
+	Output   string   `mapstructure:"output"`
+	BuildArg []string `mapstructure:"build_arg"`
 }

--- a/pkg/docker/builder.go
+++ b/pkg/docker/builder.go
@@ -15,7 +15,7 @@ type ImageBuilderTagger struct {
 	dryRun bool
 }
 
-// NewImageBuilderTagger creates a new instance of an ImageBuilder.
+// NewImageBuilderTagger creates a new instance of an ImageBuilderTagger.
 func NewImageBuilderTagger(executor exec.Executor, dryRun bool) *ImageBuilderTagger {
 	return &ImageBuilderTagger{executor, dryRun}
 }
@@ -37,7 +37,7 @@ func (b ImageBuilderTagger) Build(opts types.ImageBuilderOpts) error {
 	}
 
 	for _, tag := range opts.Tags {
-		dockerArgs = append(dockerArgs, "--tag="+tag)
+		dockerArgs = append(dockerArgs, fmt.Sprintf("--tag=%s", tag))
 	}
 
 	dockerArgs = append(dockerArgs, opts.Context)
@@ -53,15 +53,15 @@ func (b ImageBuilderTagger) Build(opts types.ImageBuilderOpts) error {
 		return nil
 	}
 
-	err := b.exec.ExecuteWithWriter(opts.LogOutput, "docker", dockerArgs...)
-	if err != nil {
+	if err := b.exec.ExecuteWithWriter(
+		opts.LogOutput, "docker", dockerArgs...); err != nil {
 		return err
 	}
 
-	if opts.Push && len(opts.Tags) > 0 {
+	if opts.Push {
 		for _, tag := range opts.Tags {
-			err = b.exec.ExecuteWithWriter(opts.LogOutput, "docker", "push", tag)
-			if err != nil {
+			if err := b.exec.ExecuteWithWriter(
+				opts.LogOutput, "docker", "push", tag); err != nil {
 				return err
 			}
 		}
@@ -70,12 +70,12 @@ func (b ImageBuilderTagger) Build(opts types.ImageBuilderOpts) error {
 	return nil
 }
 
-// Tag runs a `docker tag`command to retag the source tag with the destination tag.
+// Tag runs a docker tag command to re-tag the source tag with the destination tag.
 func (b ImageBuilderTagger) Tag(src, dest string) error {
 	if b.dryRun {
 		logger.Infof("[DRY-RUN] docker tag %s %s", src, dest)
 		return nil
 	}
-	logger.Debugf("Running `docker tag %s %s`", src, dest)
+
 	return b.exec.ExecuteStdout("docker", "tag", src, dest)
 }

--- a/pkg/dockerfile/dockerfile_test.go
+++ b/pkg/dockerfile/dockerfile_test.go
@@ -10,13 +10,14 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func Test(t *testing.T) {
+func TestParseDockerfile(t *testing.T) {
 	t.Parallel()
 
 	tests := map[string]struct {
 		filename       string
 		expectedFrom   []dockerfile.ImageRef
 		expectedLabels map[string]string
+		expectedArgs   map[string]string
 	}{
 		"simple dockerfile": {
 			filename: "simple.dockerfile",
@@ -30,6 +31,7 @@ func Test(t *testing.T) {
 			expectedLabels: map[string]string{
 				"name": "example",
 			},
+			expectedArgs: map[string]string{},
 		},
 		"simple dockerfile with digest": {
 			filename: "simple-digest.dockerfile",
@@ -43,6 +45,7 @@ func Test(t *testing.T) {
 			expectedLabels: map[string]string{
 				"name": "example",
 			},
+			expectedArgs: map[string]string{},
 		},
 		"simple dockerfile with tag": {
 			filename: "simple-tag.dockerfile",
@@ -55,6 +58,21 @@ func Test(t *testing.T) {
 			},
 			expectedLabels: map[string]string{
 				"name": "example",
+			},
+			expectedArgs: map[string]string{},
+		},
+		"simple dockerfile with arg": {
+			filename: "simple-arg.dockerfile",
+			expectedFrom: []dockerfile.ImageRef{
+				{
+					Name:   "registry.com/example",
+					Tag:    "latest",
+					Digest: "",
+				},
+			},
+			expectedLabels: map[string]string{},
+			expectedArgs: map[string]string{
+				"HELLO": `ARG HELLO="there"`,
 			},
 		},
 		"simple dockerfile with tag and digest": {
@@ -69,6 +87,7 @@ func Test(t *testing.T) {
 			expectedLabels: map[string]string{
 				"name": "example",
 			},
+			expectedArgs: map[string]string{},
 		},
 		"multistage dockerfile": {
 			filename: "multistage.dockerfile",
@@ -87,6 +106,7 @@ func Test(t *testing.T) {
 			expectedLabels: map[string]string{
 				"name": "example",
 			},
+			expectedArgs: map[string]string{},
 		},
 		"multistage dockerfile with digest": {
 			filename: "multistage-digest.dockerfile",
@@ -105,6 +125,7 @@ func Test(t *testing.T) {
 			expectedLabels: map[string]string{
 				"name": "example",
 			},
+			expectedArgs: map[string]string{},
 		},
 		"multistage dockerfile with tag": {
 			filename: "multistage-tag.dockerfile",
@@ -123,6 +144,7 @@ func Test(t *testing.T) {
 			expectedLabels: map[string]string{
 				"name": "example",
 			},
+			expectedArgs: map[string]string{},
 		},
 		"multistage dockerfile with tag and digest": {
 			filename: "multistage-tag-digest.dockerfile",
@@ -141,6 +163,7 @@ func Test(t *testing.T) {
 			expectedLabels: map[string]string{
 				"name": "example",
 			},
+			expectedArgs: map[string]string{},
 		},
 	}
 	for name, test := range tests {
@@ -149,15 +172,15 @@ func Test(t *testing.T) {
 			t.Parallel()
 
 			cwd, err := os.Getwd()
-			if err != nil {
-				t.Fatal("Failed to get current working directory.")
-			}
-			fullpath := path.Join(cwd, "../../test/fixtures/dockerfile", test.filename)
+			require.NoError(t, err)
 
+			fullpath := path.Join(cwd, "../../test/fixtures/dockerfile", test.filename)
 			result, err := dockerfile.ParseDockerfile(fullpath)
 			require.NoError(t, err)
+
 			assert.Equal(t, test.expectedFrom, result.From)
 			assert.Equal(t, test.expectedLabels, result.Labels)
+			assert.Equal(t, test.expectedArgs, result.Args)
 		})
 	}
 }

--- a/pkg/exec/shell.go
+++ b/pkg/exec/shell.go
@@ -38,8 +38,9 @@ func (e ShellExecutor) Execute(name string, args ...string) (string, error) {
 	cmd.Stdout = &stdout
 	cmd.Dir = e.Dir
 
+	logger.Debugf("Exec cmd: %s", cmd)
 	if err := cmd.Run(); err != nil {
-		return stderr.String(), fmt.Errorf("failed to execute command `%s`: %w", name, err)
+		return stderr.String(), fmt.Errorf("failed to execute command: %s: %w", cmd, err)
 	}
 
 	return stdout.String(), nil
@@ -53,9 +54,9 @@ func (e ShellExecutor) ExecuteWithWriters(stdout, stderr io.Writer, name string,
 	cmd.Stdout = stdout
 	cmd.Dir = e.Dir
 
-	logger.Debugf("cmd: %s", cmd.String())
+	logger.Debugf("Exec cmd: %s", cmd)
 	if err := cmd.Run(); err != nil {
-		return fmt.Errorf("failed to execute command `%s`: %w", name, err)
+		return fmt.Errorf("failed to execute command: %s: %w", cmd, err)
 	}
 
 	return nil
@@ -63,10 +64,12 @@ func (e ShellExecutor) ExecuteWithWriters(stdout, stderr io.Writer, name string,
 
 // ExecuteWithWriter executes a command and forwards both stdout and stderr to a single io.Writer.
 func (e ShellExecutor) ExecuteWithWriter(writer io.Writer, name string, args ...string) error {
+	logger.Debugf("Exec cmd: %s %v", name, args)
 	return e.ExecuteWithWriters(writer, writer, name, args...)
 }
 
 // ExecuteStdout executes a shell command and prints to the standard output.
 func (e ShellExecutor) ExecuteStdout(name string, args ...string) error {
+	logger.Debugf("Exec cmd: %s %v", name, args)
 	return e.ExecuteWithWriters(os.Stdout, os.Stderr, name, args...)
 }

--- a/pkg/graphviz/graphviz_test.go
+++ b/pkg/graphviz/graphviz_test.go
@@ -18,7 +18,9 @@ func Test_GenerateDotviz(t *testing.T) {
 	require.NoError(t, err)
 
 	graph, err := dib.GenerateDAG(
-		path.Join(cwd, "../../test/fixtures/docker"), "eu.gcr.io/my-test-repository", "")
+		path.Join(cwd, "../../test/fixtures/docker"),
+		"eu.gcr.io/my-test-repository", "",
+		map[string]string{})
 	require.NoError(t, err)
 
 	dir, err := os.MkdirTemp("/tmp", "dib-test")

--- a/pkg/kaniko/builder.go
+++ b/pkg/kaniko/builder.go
@@ -18,7 +18,7 @@ import (
 type ContextProvider interface {
 	// PrepareContext allows to do some operations on the build context before the executor runs,
 	// like moving it to a remote location in order to be accessible by remote executors.
-	// It must returns an URL compatible with Kaniko's `--context` flag.
+	// It must return a URL compatible with Kaniko's `--context` flag.
 	PrepareContext(opts types.ImageBuilderOpts) (string, error)
 }
 
@@ -83,7 +83,7 @@ func (b Builder) Build(opts types.ImageBuilderOpts) error {
 	}
 
 	for _, tag := range opts.Tags {
-		kanikoArgs = append(kanikoArgs, "--destination="+tag)
+		kanikoArgs = append(kanikoArgs, fmt.Sprintf("--destination=%s", tag))
 	}
 
 	for k, v := range opts.BuildArgs {

--- a/test/fixtures/docker/bullseye/Dockerfile
+++ b/test/fixtures/docker/bullseye/Dockerfile
@@ -2,3 +2,7 @@ FROM debian:bullseye
 
 LABEL name="bullseye"
 LABEL version="v1"
+
+ARG HELLO="there"
+
+RUN echo "Hello $HELLO"

--- a/test/fixtures/dockerfile/simple-arg.dockerfile
+++ b/test/fixtures/dockerfile/simple-arg.dockerfile
@@ -1,0 +1,2 @@
+FROM registry.com/example:latest
+ARG HELLO="there"


### PR DESCRIPTION
It is now possible to pass build-time variables with the `--build-arg` option for the `dib build` command:

```
dib build \
    --build-arg FOO1="bar1" \
    --build-arg FOO2=$BAR2 \
    --build-arg FOO3=${BAR3}
```

Alternatively, build arguments can also be set in the `.dib.yaml` config file:

```
build_arg:
  - FOO1="bar1"
  - FOO2=$BAR
  - FOO3=${BAR}
```