### PR TITLE
fix(logger): Redirect logs to stderr instead of stdout

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -79,9 +79,11 @@ func initConfig() {
 	viper.AutomaticEnv()                                   // read in environment variables that match
 
 	// If a config file is found, read it in.
-	if err := viper.ReadInConfig(); err == nil {
-		logger.Infof("Using config file: %s", viper.ConfigFileUsed())
+	if err := viper.ReadInConfig(); err != nil {
+		logger.Errorf("Unable read from config: %s", err)
+		os.Exit(1)
 	}
+	logger.Infof("Using config file: %s", viper.ConfigFileUsed())
 }
 
 func initConfigFile() {
@@ -99,7 +101,7 @@ func initConfigFile() {
 			viper.SetConfigFile(configFile)
 			return
 		}
-		fmt.Printf("Config file not found at %s\n", configFile) //nolint: forbidigo
+		logger.Errorf("Config file not found at \"%s\"", configFile)
 		os.Exit(1)
 	}
 

--- a/internal/logger/logger.go
+++ b/internal/logger/logger.go
@@ -30,7 +30,7 @@ var (
 	logger        atomic.Value
 	defaultLevel  = "info"
 	defaultLogger = Logger{
-		Writer: os.Stdout,
+		Writer: os.Stderr,
 		Level:  LogLevelInfo,
 	}
 


### PR DESCRIPTION
Updates pterm logger output to stderr instead of stdout.

We are having somes issues on `v0.21.0` with commands whose output is redirected to a file.

Ex :

With `v0.21.0` version :
```sh
$ dib list > dib_managed.txt

$ cat dib_managed.txt
[90m12:29:13[0m [30;46m[30;46m INFO  [0m[0m [96m[96mUsing config file: /tmp/tests/.dib.yaml[0m[0m
  NAME                                HASH                                        
  debian-test                         network-minnesota-nuts-montana              
  debian-test-curl                    michigan-missouri-artist-skylark            
  debian-test-git                     mango-sad-venus-kitten                      
  debian-test-lorem                   carbon-carolina-mountain-white              
```

With fixed version on this branch :
```sh
$ dib list > dib_managed.txt
12:34:09  INFO   Using config file: /tmp/tests/.dib.yaml

$ cat dib_managed.txt
  NAME                                HASH                                        
  debian-test                         network-minnesota-nuts-montana              
  debian-test-curl                    michigan-missouri-artist-skylark            
  debian-test-git                     mango-sad-venus-kitten                      
  debian-test-lorem                   carbon-carolina-mountain-white              
```