### PR TITLE
fix(config): No longer crashes on startup when config file doesn't exist, just warns user

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -80,8 +80,9 @@ func initConfig() {
 
 	// If a config file is found, read it in.
 	if err := viper.ReadInConfig(); err != nil {
-		logger.Errorf("Unable read from config: %s", err)
-		os.Exit(1)
+		// Non-blocking, because some command does not require config file, ie: docgen.
+		logger.Warnf("Unable read from config: %s", err)
+		return
 	}
 	logger.Infof("Using config file: %s", viper.ConfigFileUsed())
 }


### PR DESCRIPTION
Avoid cmd "docgen" to crash: https://github.com/radiofrance/dib/actions/runs/7696956248/job/20972888235#step:5:147

This command does not require any configuration file