### PR TITLE
refactor: GenerateDAG tests

### DIFF
--- a/cmd/build.go
+++ b/cmd/build.go
@@ -98,7 +98,10 @@ func doBuild(opts dib.BuildOpts) error {
 	logger.Infof("Building images in directory \"%s\"", buildPath)
 
 	logger.Debugf("Generate DAG")
-	graph := dib.GenerateDAG(buildPath, opts.RegistryURL, opts.HashListFilePath)
+	graph, err := dib.GenerateDAG(buildPath, opts.RegistryURL, opts.HashListFilePath)
+	if err != nil {
+		return fmt.Errorf("cannot generate DAG: %w", err)
+	}
 	logger.Debugf("Generate DAG -- Done")
 
 	dibBuilder := dib.Builder{

--- a/cmd/list.go
+++ b/cmd/list.go
@@ -46,6 +46,10 @@ func doList(opts dib.ListOpts) error {
 	}
 
 	buildPath := path.Join(workingDir, opts.BuildPath)
-	graph := dib.GenerateDAG(buildPath, opts.RegistryURL, opts.HashListFilePath)
+	graph, err := dib.GenerateDAG(buildPath, opts.RegistryURL, opts.HashListFilePath)
+	if err != nil {
+		return fmt.Errorf("cannot generate DAG: %w", err)
+	}
+
 	return dib.GenerateList(graph, formatOpts)
 }

--- a/pkg/graphviz/graphviz_test.go
+++ b/pkg/graphviz/graphviz_test.go
@@ -1,7 +1,6 @@
 package graphviz_test
 
 import (
-	"log"
 	"os"
 	"path"
 	"testing"
@@ -16,20 +15,18 @@ func Test_GenerateDotviz(t *testing.T) {
 	t.Parallel()
 
 	cwd, err := os.Getwd()
-	if err != nil {
-		t.Fatal("Failed to get current working directory.")
-	}
+	require.NoError(t, err)
 
-	DAG := dib.GenerateDAG(path.Join(cwd, "../../test/fixtures/docker"), "eu.gcr.io/my-test-repository", "")
+	graph, err := dib.GenerateDAG(
+		path.Join(cwd, "../../test/fixtures/docker"), "eu.gcr.io/my-test-repository", "")
+	require.NoError(t, err)
 
 	dir, err := os.MkdirTemp("/tmp", "dib-test")
-	if err != nil {
-		log.Fatal(err)
-	}
+	require.NoError(t, err)
 	defer os.RemoveAll(dir)
 
 	dotFile := path.Join(dir, "dib.dot")
-	err = graphviz.GenerateDotviz(DAG, dotFile)
+	err = graphviz.GenerateDotviz(graph, dotFile)
 	require.NoError(t, err)
 	assert.FileExists(t, dotFile)
 

--- a/test/fixtures/docker/bullseye/multistage/Dockerfile
+++ b/test/fixtures/docker/bullseye/multistage/Dockerfile
@@ -3,3 +3,4 @@ FROM eu.gcr.io/my-test-repository/node:v1
 
 LABEL name="multistage"
 LABEL version="v1"
+LABEL dib.extra-tags="latest"

--- a/test/fixtures/docker/bullseye/sub-image/Dockerfile
+++ b/test/fixtures/docker/bullseye/sub-image/Dockerfile
@@ -2,3 +2,4 @@ FROM eu.gcr.io/my-test-repository/bullseye:v1
 
 LABEL name="sub-image"
 LABEL version="v1"
+LABEL dib.use-custom-hash-list="true"


### PR DESCRIPTION
GenerateDAG tests are now using the dockerfiles already present in the tests fixtures instead of creating new ones from scratch, and are simpler to understand.