### PR TITLE
fix(CI): remove golangci-lint skip-pkg-cache option

### DIFF
--- a/.github/workflows/qa.yml
+++ b/.github/workflows/qa.yml
@@ -28,7 +28,6 @@ jobs:
         with:
           # renovate: datasource=github-releases depName=golangci/golangci-lint
           version: v1.57.2
-          skip-pkg-cache: true
 
   tests:
     name: Run tests


### PR DESCRIPTION
From [release notes of golangci-lint action v5.0.0](https://github.com/golangci/golangci-lint-action/releases/tag/v5.0.0):

> `skip-pkg-cache` and `skip-build-cache` have been removed because the cache related to Go itself is already handled by actions/setup-go.