### PR TITLE
refact(GenerateDAG): new internal tests

### DIFF
--- a/pkg/dib/generate_dag_internal_test.go
+++ b/pkg/dib/generate_dag_internal_test.go
@@ -1,0 +1,59 @@
+package dib
+
+import (
+	"testing"
+
+	"github.com/davecgh/go-spew/spew"
+	"github.com/radiofrance/dib/pkg/dag"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+const (
+	buildPath      = "../../test/fixtures/docker"
+	registryPrefix = "eu.gcr.io/my-test-repository"
+)
+
+func Test_buildGraph(t *testing.T) {
+	t.Parallel()
+
+	graph, err := buildGraph(buildPath, registryPrefix)
+	require.NoError(t, err)
+	graph.WalkInDepth(func(node *dag.Node) {
+		switch node.Image.ShortName {
+		case "root1":
+			require.Len(t, node.Files, 9, spew.Sdump(node.Files))
+			assert.Contains(t, node.Files, buildPath+"/root1/Dockerfile")
+			assert.Contains(t, node.Files, buildPath+"/root1/custom-hash-list/Dockerfile")
+			assert.Contains(t, node.Files, buildPath+"/root1/dockerignore/.dockerignore")
+			assert.Contains(t, node.Files, buildPath+"/root1/dockerignore/Dockerfile")
+			assert.Contains(t, node.Files, buildPath+"/root1/dockerignore/ignored.txt")
+			assert.Contains(t, node.Files, buildPath+"/root1/multistage/Dockerfile")
+			assert.Contains(t, node.Files, buildPath+"/root1/skipbuild/Dockerfile")
+			assert.Contains(t, node.Files, buildPath+"/root1/with-a-file/Dockerfile")
+			assert.Contains(t, node.Files, buildPath+"/root1/with-a-file/included.txt")
+		case "custom-hash-list":
+			require.Len(t, node.Files, 1, spew.Sdump(node.Files))
+			assert.Contains(t, node.Files, buildPath+"/root1/custom-hash-list/Dockerfile")
+		case "dockerignore":
+			require.Len(t, node.Files, 1, spew.Sdump(node.Files))
+			assert.Contains(t, node.Files, buildPath+"/root1/dockerignore/Dockerfile")
+		case "multistage":
+			require.Len(t, node.Files, 1, spew.Sdump(node.Files))
+			assert.Contains(t, node.Files, buildPath+"/root1/multistage/Dockerfile")
+		case "with-a-file":
+			require.Len(t, node.Files, 2, spew.Sdump(node.Files))
+			assert.Contains(t, node.Files, buildPath+"/root1/with-a-file/Dockerfile")
+			assert.Contains(t, node.Files, buildPath+"/root1/with-a-file/included.txt")
+		case "root2":
+			require.Len(t, node.Files, 2, spew.Sdump(node.Files))
+			assert.Contains(t, node.Files, buildPath+"/root2/Dockerfile")
+			assert.Contains(t, node.Files, buildPath+"/root2/root3/Dockerfile")
+		case "root3":
+			require.Len(t, node.Files, 1, spew.Sdump(node.Files))
+			assert.Contains(t, node.Files, buildPath+"/root2/root3/Dockerfile")
+		default:
+			t.Errorf("unexpected image: %s", node.Image.ShortName)
+		}
+	})
+}

--- a/pkg/graphviz/graphviz_test.go
+++ b/pkg/graphviz/graphviz_test.go
@@ -34,19 +34,17 @@ func Test_GenerateDotviz(t *testing.T) {
 
 	content, err := os.ReadFile(dotFile)
 	require.NoError(t, err)
-	assert.Len(t, content, 647)
-	assert.Contains(t, string(content),
-		"\"eu.gcr.io/my-test-repository/bullseye\" [fillcolor=white style=filled];")
-	assert.Contains(t, string(content),
-		"\"eu.gcr.io/my-test-repository/bullseye\" -> \"eu.gcr.io/my-test-repository/kaniko\";")
-	assert.Contains(t, string(content),
-		"\"eu.gcr.io/my-test-repository/bullseye\" -> \"eu.gcr.io/my-test-repository/multistage\";")
-	assert.Contains(t, string(content),
-		"\"eu.gcr.io/my-test-repository/bullseye\" -> \"eu.gcr.io/my-test-repository/sub-image\";")
-	assert.Contains(t, string(content),
-		"\"eu.gcr.io/my-test-repository/kaniko\" [fillcolor=white style=filled];")
-	assert.Contains(t, string(content),
-		"\"eu.gcr.io/my-test-repository/multistage\" [fillcolor=white style=filled];")
-	assert.Contains(t, string(content),
-		"\"eu.gcr.io/my-test-repository/sub-image\" [fillcolor=white style=filled];")
+	f := string(content)
+	assert.Len(t, f, 958)
+	assert.Contains(t, f, `"eu.gcr.io/my-test-repository/root1" [fillcolor=white style=filled];`)
+	assert.Contains(t, f, `"eu.gcr.io/my-test-repository/custom-hash-list" [fillcolor=white style=filled];`)
+	assert.Contains(t, f, `"eu.gcr.io/my-test-repository/dockerignore" [fillcolor=white style=filled];`)
+	assert.Contains(t, f, `"eu.gcr.io/my-test-repository/multistage" [fillcolor=white style=filled];`)
+	assert.Contains(t, f, `"eu.gcr.io/my-test-repository/with-a-file" [fillcolor=white style=filled];`)
+	assert.Contains(t, f, `"eu.gcr.io/my-test-repository/root2" [fillcolor=white style=filled];`)
+	assert.Contains(t, f, `"eu.gcr.io/my-test-repository/root3" [fillcolor=white style=filled];`)
+	assert.Contains(t, f, `"eu.gcr.io/my-test-repository/root1" -> "eu.gcr.io/my-test-repository/custom-hash-list";`)
+	assert.Contains(t, f, `"eu.gcr.io/my-test-repository/root1" -> "eu.gcr.io/my-test-repository/dockerignore";`)
+	assert.Contains(t, f, `"eu.gcr.io/my-test-repository/root1" -> "eu.gcr.io/my-test-repository/multistage";`)
+	assert.Contains(t, f, `"eu.gcr.io/my-test-repository/root1" -> "eu.gcr.io/my-test-repository/with-a-file";`)
 }

--- a/test/fixtures/docker-duplicates/bullseye/duplicate1/Dockerfile
+++ b/test/fixtures/docker-duplicates/bullseye/duplicate1/Dockerfile
@@ -1,5 +1,0 @@
-FROM eu.gcr.io/my-test-repository/bullseye:v1
-
-LABEL name="duplicate"
-LABEL version="v1"
-LABEL dib.use-custom-hash-list="true"

--- a/test/fixtures/docker-duplicates/bullseye/duplicate2/Dockerfile
+++ b/test/fixtures/docker-duplicates/bullseye/duplicate2/Dockerfile
@@ -1,5 +1,0 @@
-FROM eu.gcr.io/my-test-repository/bullseye:v1
-
-LABEL name="duplicate"
-LABEL version="v2"
-LABEL dib.use-custom-hash-list="true"

--- a/test/fixtures/docker-duplicates/root/Dockerfile
+++ b/test/fixtures/docker-duplicates/root/Dockerfile
@@ -1,0 +1,3 @@
+FROM debian:bullseye
+
+LABEL name="root"

--- a/test/fixtures/docker-duplicates/root/duplicate1/Dockerfile
+++ b/test/fixtures/docker-duplicates/root/duplicate1/Dockerfile
@@ -1,0 +1,3 @@
+FROM eu.gcr.io/my-test-repository/root
+
+LABEL name="duplicate"

--- a/test/fixtures/docker-duplicates/root/duplicate2/Dockerfile
+++ b/test/fixtures/docker-duplicates/root/duplicate2/Dockerfile
@@ -1,0 +1,3 @@
+FROM eu.gcr.io/my-test-repository/root
+
+LABEL name="duplicate"

--- a/test/fixtures/docker/bullseye/Dockerfile
+++ b/test/fixtures/docker/bullseye/Dockerfile
@@ -1,8 +1,0 @@
-FROM debian:bullseye
-
-LABEL name="bullseye"
-LABEL version="v1"
-
-ARG HELLO="there"
-
-RUN echo "Hello $HELLO"

--- a/test/fixtures/docker/bullseye/external-parent/Dockerfile
+++ b/test/fixtures/docker/bullseye/external-parent/Dockerfile
@@ -1,9 +1,0 @@
-# Check for new release: https://github.com/GoogleContainerTools/kaniko/tags
-ARG KANIKO_VERSION=v1.6.0
-# We are using official Docker image as base
-FROM gcr.io/kaniko-project/executor:${KANIKO_VERSION} as kaniko_artifacts
-
-FROM eu.gcr.io/my-test-repository/bullseye:v1
-LABEL name="kaniko"
-LABEL version="16"
-

--- a/test/fixtures/docker/bullseye/multistage/Dockerfile
+++ b/test/fixtures/docker/bullseye/multistage/Dockerfile
@@ -1,6 +1,0 @@
-FROM eu.gcr.io/my-test-repository/bullseye:v1 as builder
-FROM eu.gcr.io/my-test-repository/node:v1
-
-LABEL name="multistage"
-LABEL version="v1"
-LABEL dib.extra-tags="latest"

--- a/test/fixtures/docker/bullseye/skipbuild/Dockerfile
+++ b/test/fixtures/docker/bullseye/skipbuild/Dockerfile
@@ -1,4 +1,0 @@
-FROM eu.gcr.io/my-test-repository/bullseye:v1
-
-LABEL name="skipbuild"
-LABEL skipbuild="true"

--- a/test/fixtures/docker/bullseye/sub-image/Dockerfile
+++ b/test/fixtures/docker/bullseye/sub-image/Dockerfile
@@ -1,5 +1,0 @@
-FROM eu.gcr.io/my-test-repository/bullseye:v1
-
-LABEL name="sub-image"
-LABEL version="v1"
-LABEL dib.use-custom-hash-list="true"

--- a/test/fixtures/docker/root1/Dockerfile
+++ b/test/fixtures/docker/root1/Dockerfile
@@ -1,6 +1,6 @@
 FROM debian:bullseye
 
-LABEL name="bullseye"
+LABEL name="root1"
 LABEL version="v1"
 
 ARG HELLO="there"

--- a/test/fixtures/docker/root1/custom-hash-list/Dockerfile
+++ b/test/fixtures/docker/root1/custom-hash-list/Dockerfile
@@ -1,0 +1,5 @@
+FROM eu.gcr.io/my-test-repository/root1:v1
+
+LABEL name="custom-hash-list"
+
+LABEL dib.use-custom-hash-list="true"

--- a/test/fixtures/docker/root1/dockerignore/.dockerignore
+++ b/test/fixtures/docker/root1/dockerignore/.dockerignore
@@ -1,0 +1,1 @@
+ignored.txt

--- a/test/fixtures/docker/root1/dockerignore/Dockerfile
+++ b/test/fixtures/docker/root1/dockerignore/Dockerfile
@@ -1,0 +1,3 @@
+FROM eu.gcr.io/my-test-repository/root1:v1
+
+LABEL name="dockerignore"

--- a/test/fixtures/docker/root1/multistage/Dockerfile
+++ b/test/fixtures/docker/root1/multistage/Dockerfile
@@ -1,0 +1,4 @@
+FROM eu.gcr.io/my-test-repository/root1:v1 as builder
+FROM vault
+
+LABEL name="multistage"

--- a/test/fixtures/docker/root1/skipbuild/Dockerfile
+++ b/test/fixtures/docker/root1/skipbuild/Dockerfile
@@ -1,0 +1,3 @@
+FROM eu.gcr.io/my-test-repository/root1:v1
+
+LABEL skipbuild="true"

--- a/test/fixtures/docker/root1/with-a-file/Dockerfile
+++ b/test/fixtures/docker/root1/with-a-file/Dockerfile
@@ -1,0 +1,3 @@
+FROM eu.gcr.io/my-test-repository/root1:v1
+
+LABEL name="with-a-file"

--- a/test/fixtures/docker/root2/Dockerfile
+++ b/test/fixtures/docker/root2/Dockerfile
@@ -1,0 +1,3 @@
+FROM apache/superset
+
+LABEL name="root2"

--- a/test/fixtures/docker/root2/root3/Dockerfile
+++ b/test/fixtures/docker/root2/root3/Dockerfile
@@ -1,0 +1,3 @@
+FROM bitnami/elasticsearch
+
+LABEL name="root3"


### PR DESCRIPTION
This PR is improving the testing of the current GenerateDAG algorithm, to show the different problems with it. 

The current algorithm has been split in two:
- The first part is building the graph and assigning files to the nodes.
- The second part is computing the hashes of the nodes.

A new internal test is proving that the first part is not working correctly, as some files are not assigned to the right nodes.