### PR TITLE
refact(GenerateDAG): split the algorithm in two parts

### DIFF
--- a/pkg/dib/generate_dag_internal_test.go
+++ b/pkg/dib/generate_dag_internal_test.go
@@ -1,0 +1,9 @@
+package dib
+
+import "testing"
+
+func Test_buildGraph(t *testing.T) {
+	t.Parallel()
+
+	// Implement me.
+}


### PR DESCRIPTION
refact(GenerateDAG): split the algorithm in two parts, buildGraph and computeHashes.

The first part buildGraph needs to be unit tested, because we found some issues with its logic.