### PR TITLE
feat(cli): add new output format "graphviz" for list command

### DIFF
--- a/cmd/list.go
+++ b/cmd/list.go
@@ -32,7 +32,7 @@ func init() {
 	rootCmd.AddCommand(listCmd)
 
 	listCmd.Flags().StringP("output", "o", "", ""+
-		"Output format (console|go-template-file)\n"+
+		"Output format (console|graphviz|go-template-file)\n"+
 		"You can provide a custom format using go-template: like this: \"-o go-template-file=...\".")
 	listCmd.Flags().StringArray("build-arg", []string{},
 		"`argument=value` to supply to the builder")

--- a/cmd/list.go
+++ b/cmd/list.go
@@ -14,8 +14,22 @@ import (
 // listCmd represents the output command.
 var listCmd = &cobra.Command{
 	Use:   "list",
-	Short: "Print list of images managed by dib",
-	Long:  `dib list will print a list of all Docker images managed by dib`,
+	Short: "List all images managed by dib",
+	Long: `Command list provide different ways to print the list of all Docker images managed by dib.
+
+The output can be customized with the --output flag :
+• console (default output)
+  ex : dib list
+
+• go-template-file (render output using a Go template)
+  ex : dib list -o go-template-file=dib_list.tmpl
+
+• graphviz (dot language output)
+  ex : dib list -o graphviz
+
+  You can also generate a PNG image from the graphviz output using the following command :
+  dib list -o graphviz | dot -Tpng > dib.png
+`,
 	Run: func(cmd *cobra.Command, _ []string) {
 		bindPFlagsSnakeCase(cmd.Flags())
 
@@ -31,9 +45,8 @@ var listCmd = &cobra.Command{
 func init() {
 	rootCmd.AddCommand(listCmd)
 
-	listCmd.Flags().StringP("output", "o", "", ""+
-		"Output format (console|graphviz|go-template-file)\n"+
-		"You can provide a custom format using go-template: like this: \"-o go-template-file=...\".")
+	listCmd.Flags().StringP("output", "o", dib.ConsoleFormat,
+		"Output format : console|graphviz|go-template-file")
 	listCmd.Flags().StringArray("build-arg", []string{},
 		"`argument=value` to supply to the builder")
 }

--- a/pkg/dib/list_test.go
+++ b/pkg/dib/list_test.go
@@ -35,7 +35,17 @@ func Test_GenerateList_Console(t *testing.T) {
 	t.Parallel()
 
 	DAG := setupFakeDag(t)
-	opts := dib.FormatOpts{Type: "console"}
+	opts := dib.FormatOpts{Type: dib.ConsoleFormat}
+	err := dib.GenerateList(DAG, opts)
+
+	require.NoError(t, err)
+}
+
+func Test_GenerateList_Graphviz(t *testing.T) {
+	t.Parallel()
+
+	DAG := setupFakeDag(t)
+	opts := dib.FormatOpts{Type: dib.GraphvizFormat}
 	err := dib.GenerateList(DAG, opts)
 
 	require.NoError(t, err)
@@ -58,17 +68,17 @@ func Test_GenerateList_GoTemplateFile(t *testing.T) {
 	}{
 		{
 			name:         "valid go-template-file",
-			outputFormat: dib.FormatOpts{Type: "go-template-file", TemplatePath: path.Join(cwd, "../../test/example_1.yml")},
+			outputFormat: dib.FormatOpts{Type: dib.GoTemplateFileFormat, TemplatePath: path.Join(cwd, "../../test/example_1.yml")},
 			expectError:  false,
 		},
 		{
 			name:         "invalid path to go-template-file",
-			outputFormat: dib.FormatOpts{Type: "go-template-file", TemplatePath: path.Join(cwd, "lorem")},
+			outputFormat: dib.FormatOpts{Type: dib.GoTemplateFileFormat, TemplatePath: path.Join(cwd, "lorem")},
 			expectError:  true,
 		},
 		{
 			name:         "invalid go-template-file (use of property that doesn't exist)",
-			outputFormat: dib.FormatOpts{Type: "go-template-file", TemplatePath: path.Join(cwd, "../../test/invalid_example.yml")},
+			outputFormat: dib.FormatOpts{Type: dib.GoTemplateFileFormat, TemplatePath: path.Join(cwd, "../../test/invalid_example.yml")},
 			expectError:  true,
 		},
 	}
@@ -118,25 +128,31 @@ func Test_ParseOutputOptions(t *testing.T) {
 	}{
 		{
 			name:             "Format: console",
-			given:            "console",
-			expected:         dib.FormatOpts{Type: "console"},
+			given:            dib.ConsoleFormat,
+			expected:         dib.FormatOpts{Type: dib.ConsoleFormat},
 			expectedErrorMsg: "",
 		},
 		{
 			name:             "Format: console (default)",
 			given:            "",
-			expected:         dib.FormatOpts{Type: "console"},
+			expected:         dib.FormatOpts{Type: dib.ConsoleFormat},
+			expectedErrorMsg: "",
+		},
+		{
+			name:             "Format: graphviz",
+			given:            dib.GraphvizFormat,
+			expected:         dib.FormatOpts{Type: dib.GraphvizFormat},
 			expectedErrorMsg: "",
 		},
 		{
 			name:             "Format: go-template-file",
-			given:            "go-template-file=/tmp/output.gotemplate",
-			expected:         dib.FormatOpts{Type: "go-template-file", TemplatePath: "/tmp/output.gotemplate"},
+			given:            dib.GoTemplateFileFormat + "=/tmp/output.gotemplate",
+			expected:         dib.FormatOpts{Type: dib.GoTemplateFileFormat, TemplatePath: "/tmp/output.gotemplate"},
 			expectedErrorMsg: "",
 		},
 		{
 			name:             "Format: go-template-file (invalid)",
-			given:            "go-template-file",
+			given:            dib.GoTemplateFileFormat,
 			expected:         dib.FormatOpts{},
 			expectedErrorMsg: "you need to provide a path to template file when using \"go-template-file\" options",
 		},


### PR DESCRIPTION
Give a possibility for the end user to print the actual state of the DAG using [graphviz](https://graphviz.org)

### HOW TO TEST

- Ensure you have `graphviz` installed : https://graphviz.org/download

- Then compile Dib locally (using GoReleaser)
```sh
make artifact
```

- And test the `dib list` command with the new option
```sh
$ ./dist/dib_linux_amd64_v1/dib list \
  --config test/end2end/.dib.yaml \
  --build-path test/end2end \
  -o graphviz

digraph images {
  rankdir = "LR";
  node[fontsize=10, shape=cds, height=0.4];
  edge[fontsize=10, arrowhead=vee];

  "registry.localhost/base-alpine-3.19" [fillcolor=white, style=filled];
  "registry.localhost/base-alpine-3.20" [fillcolor=white, style=filled];
  "registry.localhost/base-debian-bookworm" [fillcolor=white, style=filled];
  "registry.localhost/base-debian-bookworm" -> "registry.localhost/app-git" [dir=forward];
  "registry.localhost/base-debian-bookworm" -> "registry.localhost/app-curl" [dir=forward];
  "registry.localhost/app-git" [fillcolor=white, style=filled];
  "registry.localhost/app-git" -> "registry.localhost/app-skipped" [dir=forward];
  "registry.localhost/app-skipped" [fillcolor=white, style=filled];
  "registry.localhost/app-curl" [fillcolor=white, style=filled];
}
```

- So we can redirect output to `dot` cmd to create the final png file
```sh
$ ./dist/dib_linux_amd64_v1/dib list \
  --config test/end2end/.dib.yaml \
  --build-path test/end2end \
  -o graphviz \
 | dot -Tpng > $HOME/Downloads/dib.png
```

If the command was successful, you should see a new `dib.png` file like this :slightly_smiling_face: 

![dib](https://github.com/user-attachments/assets/df42ae89-5b2b-48a5-8719-d1a222ea154b)

