### PR TITLE
CI: ubuntu-24.04-amd64 -> ubuntu-24.04-arm

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -11,7 +11,7 @@ permissions:
 
 jobs:
   publish-docs:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04-arm
     permissions:
       contents: write
     steps:

--- a/.github/workflows/qa.yml
+++ b/.github/workflows/qa.yml
@@ -18,7 +18,7 @@ permissions:
 jobs:
   lint:
     name: Run linters
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04-arm
     env:
       # renovate: datasource=github-releases depName=radiofrance/lint-config
       LINT_CONFIG_VERSION: v1.0.1
@@ -36,7 +36,7 @@ jobs:
 
   tests:
     name: Run tests
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04-arm
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
       - uses: actions/setup-go@f111f3307d8850f501ac008e886eec1fd1932a34 # v5.3.0
@@ -53,7 +53,7 @@ jobs:
   codecov:
     name: Upload coverage to Codecov
     needs: [tests]
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04-arm
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
       - uses: actions/download-artifact@fa0a91b85d4f404e444e00e005971372dc801d16 # v4.1.8

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -6,7 +6,7 @@ on: # yamllint disable-line rule:truthy
 
 jobs:
   goreleaser:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -10,7 +10,7 @@ jobs:
   # - Check if no issues are found on your GitHub Actions
   # - Ensure that all GitHub Actions and reusable workflow are pinned using directly a commit SHA
   actions_security:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04-arm
     permissions:
       security-events: write
     steps:

--- a/.github/workflows/yaml.yml
+++ b/.github/workflows/yaml.yml
@@ -7,9 +7,13 @@ on: # yamllint disable-line rule:truthy
 
 jobs:
   lintyaml:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04-arm
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+      # yamllint is not yet available in ubuntu-24.04-arm (https://github.com/actions/partner-runner-images/blob/main/images/arm-ubuntu-24-image.md)
+      # request https://github.com/actions/partner-runner-images/issues/56
+      - name: Install yamllint
+        run: sudo apt-get update && sudo apt-get install -y --no-install-recommends yamllint
       - uses: ibiqlik/action-yamllint@2576378a8e339169678f9939646ee3ee325e845c # tag=v3.1.1
         with:
           format: github


### PR DESCRIPTION
Hi folks,

GHA now provides ARM runners for free

https://github.blog/changelog/2025-01-16-linux-arm64-hosted-runners-now-available-for-free-in-public-repositories-public-preview/