### PR TITLE
maint(golangci-lint): bump to v2.1.2

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -16,7 +16,7 @@ jobs:
       contents: write
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
-      - uses: actions/setup-go@f111f3307d8850f501ac008e886eec1fd1932a34 # v5.3.0
+      - uses: actions/setup-go@0aaccfd150d50ccaeb58ebd88d36e91967a5f35b # v5.4.0
         with:
           go-version-file: "go.mod"
       - name: Generate cmd docs

--- a/.github/workflows/qa.yml
+++ b/.github/workflows/qa.yml
@@ -21,25 +21,25 @@ jobs:
     runs-on: ubuntu-24.04-arm
     env:
       # renovate: datasource=github-releases depName=radiofrance/lint-config
-      LINT_CONFIG_VERSION: v1.0.4
+      LINT_CONFIG_VERSION: v1.1.0
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
-      - uses: actions/setup-go@f111f3307d8850f501ac008e886eec1fd1932a34 # v5.3.0
+      - uses: actions/setup-go@0aaccfd150d50ccaeb58ebd88d36e91967a5f35b # v5.4.0
         with:
           go-version-file: "go.mod"
       - name: Download golangci-lint config file
         run: curl -o .golangci.yml https://raw.githubusercontent.com/radiofrance/lint-config/${{ env.LINT_CONFIG_VERSION }}/.golangci.yml
-      - uses: golangci/golangci-lint-action@ec5d18412c0aeab7936cb16880d708ba2a64e1ae # v6.2.0
+      - uses: golangci/golangci-lint-action@1481404843c368bc19ca9406f87d6e0fc97bdcfd # v7.0.0
         with:
           # renovate: datasource=github-releases depName=golangci/golangci-lint
-          version: v1.64.6
+          version: v2.1.2
 
   tests:
     name: Run tests
     runs-on: ubuntu-24.04-arm
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
-      - uses: actions/setup-go@f111f3307d8850f501ac008e886eec1fd1932a34 # v5.3.0
+      - uses: actions/setup-go@0aaccfd150d50ccaeb58ebd88d36e91967a5f35b # v5.4.0
         with:
           go-version-file: "go.mod"
       - uses: tlylt/install-graphviz@b2201200d85f06f0189cb74d9b69208504cf12cd # v1.0.0

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -11,7 +11,7 @@ jobs:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:
           fetch-depth: 0
-      - uses: actions/setup-go@f111f3307d8850f501ac008e886eec1fd1932a34 # v5.3.0
+      - uses: actions/setup-go@0aaccfd150d50ccaeb58ebd88d36e91967a5f35b # v5.4.0
         with:
           go-version-file: "go.mod"
       - uses: goreleaser/goreleaser-action@9c156ee8a17a598857849441385a2041ef570552 # v6.3.0

--- a/.renovaterc.json
+++ b/.renovaterc.json
@@ -52,6 +52,18 @@
       "groupName": "golang"
     },
     {
+      "description": "Group golangci-lint related bumps",
+      "matchPackageNames": [
+        "catalog/golang/golangci-lint",
+        "golangci/golangci-lint-action",
+        "radiofrance/lint-config"
+      ],
+      "groupName": "golangci-lint",
+      "groupSlug": "golangci-lint",
+      "separateMinorPatch": false,
+      "separateMajorMinor": false
+    },
+    {
       "description": "Update Go directives in go.mod files",
       "matchManagers": ["gomod"],
       "matchDepNames": ["go"],
@@ -65,14 +77,15 @@
   ],
   "customManagers": [
     {
+      "description": "Update variables in Makefile and GitHub Actions files",
       "customType": "regex",
       "fileMatch": [
+        "(^|/)Makefile$",
         "^\\.github/workflows/.*\\.ya?ml"
       ],
       "matchStrings": [
-        "# renovate: datasource=(?<datasource>.*?)(?: depName=(?<depName>.*?))?(?: versioning=(?<versioning>.*?))?\\s.*version: ['\"]?(?<currentValue>[^'\"\\s]+)['\"]?\\s"
-      ],
-      "versioningTemplate": "{{#if versioning}}{{versioning}}{{else}}semver{{/if}}"
+        "#\\s*renovate:\\s*datasource=(?<datasource>.*?) depName=(?<depName>.*?)(?: versioning=(?<versioning>.*?))?\\s+.*\\s*[:=]\\s*['\"]?(?<currentValue>.+?)['\"]?\\s"
+      ]
     }
   ]
 }

--- a/.renovaterc.json
+++ b/.renovaterc.json
@@ -54,7 +54,7 @@
     {
       "description": "Group golangci-lint related bumps",
       "matchPackageNames": [
-        "catalog/golang/golangci-lint",
+        "golangci/golangci-lint",
         "golangci/golangci-lint-action",
         "radiofrance/lint-config"
       ],

--- a/Makefile
+++ b/Makefile
@@ -36,11 +36,12 @@ docs: build
 
 qa: lint test
 
-LINT_CONFIG_VERSION = v1.0.4
+# renovate: datasource=github-releases depName=radiofrance/lint-config
+LINT_CONFIG_VERSION = v1.1.0
 
 lint: ## Lint source code
 	curl -o .golangci.yml -sS \
-		"https://raw.githubusercontent.com/radiofrance/lint-config/${LINT_CONFIG_VERSION}/.golangci.yml"
+		"https://raw.githubusercontent.com/radiofrance/lint-config/$(LINT_CONFIG_VERSION)/.golangci.yml"
 	golangci-lint run --verbose
 
 PKG = ./...

--- a/cmd/docgen.go
+++ b/cmd/docgen.go
@@ -33,7 +33,7 @@ func init() {
 }
 
 func docgenCmdRun(_ *cobra.Command, _ []string) error {
-	if err := os.MkdirAll(cmdDocPath, os.ModePerm); err != nil {
+	if err := os.MkdirAll(cmdDocPath, 0o750); err != nil {
 		return err
 	}
 

--- a/pkg/buildkit/buildkitutil.go
+++ b/pkg/buildkit/buildkitutil.go
@@ -64,7 +64,7 @@ func pingBKDaemon(buildkitHost string) (string, error) {
 	}
 	args := buildctlBaseArgs(buildkitHost)
 	args = append(args, "debug", "workers")
-	buildctlCheckCmd := exec.Command(buildctlBinary, args...)
+	buildctlCheckCmd := exec.Command(buildctlBinary, args...) //nolint:gosec
 	buildctlCheckCmd.Env = os.Environ()
 	if out, err := buildctlCheckCmd.CombinedOutput(); err != nil {
 		return string(out), err

--- a/pkg/buildkit/buildkitutil_test.go
+++ b/pkg/buildkit/buildkitutil_test.go
@@ -104,8 +104,8 @@ func TestBuildKitFile(t *testing.T) {
 
 			absDir, bkFile, err := buildKitFile(dir, file)
 			if tt.expectedError {
-				assert.Equal(t, "", absDir)
-				assert.Equal(t, "", bkFile)
+				assert.Empty(t, absDir)
+				assert.Empty(t, bkFile)
 				assert.Error(t, err)
 			} else {
 				assert.Equal(t, dir, absDir)

--- a/pkg/dib/build.go
+++ b/pkg/dib/build.go
@@ -93,7 +93,7 @@ func (p *Builder) rebuildGraph(
 		WalkParallel(
 			func(node *dag.Node) {
 				img := node.Image
-				if !(img.NeedsRebuild || img.NeedsTests) {
+				if !img.NeedsRebuild && !img.NeedsTests {
 					img.RebuildFailed = false
 					return
 				}
@@ -184,13 +184,13 @@ func buildNode(
 		}
 	}()
 
-	if err := os.MkdirAll(buildReportDir, 0o755); err != nil {
+	if err := os.MkdirAll(buildReportDir, 0o750); err != nil {
 		return fmt.Errorf("failed to create folder %s: %w", buildReportDir, err)
 	}
 
 	filePath := path.Join(buildReportDir, fmt.Sprintf("%s.txt", strings.ReplaceAll(img.ShortName, "/", "_")))
 	var err error
-	opts.LogOutput, err = os.Create(filePath)
+	opts.LogOutput, err = os.Create(filePath) //nolint:gosec
 	if err != nil {
 		return fmt.Errorf("failed to create file %s: %w", filePath, err)
 	}

--- a/pkg/dib/build_test.go
+++ b/pkg/dib/build_test.go
@@ -230,7 +230,7 @@ func newTestNode(needsRebuild, needsTests, rebuildFailed bool) *dag.Node {
 }
 
 func countFilesInDirectory(dirPath string) int {
-	if err := os.MkdirAll(dirPath, 0o755); err != nil && !os.IsExist(err) {
+	if err := os.MkdirAll(dirPath, 0o750); err != nil && !os.IsExist(err) {
 		panic(err)
 	}
 

--- a/pkg/dib/generate_dag.go
+++ b/pkg/dib/generate_dag.go
@@ -273,11 +273,13 @@ func hashFiles(baseDir string, files, parentHashes, hashList []string) (string, 
 			return "", errors.New("file names with newlines are not supported")
 		}
 
-		file, err := os.Open(filename)
+		file, err := os.Open(filename) //nolint:gosec
 		if err != nil {
 			return "", err
 		}
-		defer file.Close()
+		defer func() {
+			_ = file.Close()
+		}()
 
 		hashFile := sha256.New()
 		if _, err := io.Copy(hashFile, file); err != nil {
@@ -309,11 +311,13 @@ func hashFiles(baseDir string, files, parentHashes, hashList []string) (string, 
 
 // loadCustomHashList try to load & parse a list of custom humanized hash to use.
 func loadCustomHashList(filepath string) ([]string, error) {
-	file, err := os.Open(filepath)
+	file, err := os.Open(filepath) //nolint:gosec
 	if err != nil {
 		return nil, err
 	}
-	defer file.Close()
+	defer func() {
+		_ = file.Close()
+	}()
 
 	fileScanner := bufio.NewScanner(file)
 	fileScanner.Split(bufio.ScanLines)

--- a/pkg/dib/generate_dag_internal_test.go
+++ b/pkg/dib/generate_dag_internal_test.go
@@ -258,7 +258,7 @@ func copyFixtures(t *testing.T) string {
 	require.NoError(t, err)
 	src := path.Join(cwd, basePath)
 	dest := t.TempDir()
-	cmd := exec.Command("cp", "-r", src, dest)
+	cmd := exec.Command("cp", "-r", src, dest) //nolint:gosec
 	require.NoError(t, cmd.Run())
 	return path.Join(dest, path.Base(basePath))
 }

--- a/pkg/dib/list.go
+++ b/pkg/dib/list.go
@@ -111,8 +111,8 @@ func renderConsoleOutput(imagesList []dag.Image) {
 	table := tablewriter.NewWriter(os.Stdout)
 	table.SetAutoWrapText(false)
 	table.SetAutoFormatHeaders(true)
-	table.SetHeaderAlignment(tablewriter.ALIGN_LEFT) //nolint:nosnakecase
-	table.SetAlignment(tablewriter.ALIGN_LEFT)       //nolint:nosnakecase
+	table.SetHeaderAlignment(tablewriter.ALIGN_LEFT)
+	table.SetAlignment(tablewriter.ALIGN_LEFT)
 	table.SetCenterSeparator("")
 	table.SetColumnSeparator("")
 	table.SetRowSeparator("")

--- a/pkg/dockerfile/dockerfile.go
+++ b/pkg/dockerfile/dockerfile.go
@@ -55,11 +55,13 @@ func IsDockerfile(filename string) bool {
 // ParseDockerfile parses an actual Dockerfile, and creates an instance of a Dockerfile struct.
 func ParseDockerfile(filename string) (*Dockerfile, error) {
 	logger.Debugf("Parsing dockerfile \"%s\"", filename)
-	file, err := os.Open(filename)
+	file, err := os.Open(filename) //nolint:gosec
 	if err != nil {
 		return nil, err
 	}
-	defer file.Close()
+	defer func() {
+		_ = file.Close()
+	}()
 
 	var dckFile Dockerfile
 	dckFile.ContextPath = path.Dir(filename)
@@ -128,7 +130,7 @@ func ResetFile(path string, diff map[string]string) error {
 }
 
 func replace(path string, previous string, next string) error {
-	read, err := os.ReadFile(path)
+	read, err := os.ReadFile(path) //nolint:gosec
 	if err != nil {
 		return err
 	}

--- a/pkg/dockerfile/dockerfile_test.go
+++ b/pkg/dockerfile/dockerfile_test.go
@@ -1,3 +1,4 @@
+//nolint:gosec
 package dockerfile_test
 
 import (

--- a/pkg/goss/runner.go
+++ b/pkg/goss/runner.go
@@ -71,7 +71,7 @@ func (b TestRunner) IsConfigured(opts types.RunTestOptions) bool {
 
 // RunTest executes goss tests on the given image. goss.yaml file is expected to be present in the given path.
 func (b TestRunner) RunTest(opts types.RunTestOptions) error {
-	if err := os.MkdirAll(opts.ReportJunitDir, 0o755); err != nil {
+	if err := os.MkdirAll(opts.ReportJunitDir, 0o750); err != nil {
 		return err
 	}
 
@@ -83,7 +83,7 @@ func (b TestRunner) RunTest(opts types.RunTestOptions) error {
 	var stdout bytes.Buffer
 	args := []string{"--format", "junit"}
 
-	testError := b.Executor.Execute(context.Background(), &stdout, opts, args...)
+	testError := b.Execute(context.Background(), &stdout, opts, args...)
 
 	if err := b.exportJunitReport(opts, stdout.String()); err != nil {
 		return fmt.Errorf("goss tests failed, could not export junit report: %w", err)

--- a/pkg/goss/runner_test.go
+++ b/pkg/goss/runner_test.go
@@ -1,3 +1,4 @@
+//nolint:gosec
 package goss_test
 
 import (
@@ -90,7 +91,7 @@ func Test_TestRunner_RunTest_Junit(t *testing.T) {
 	})
 
 	dibReport := report.Init("1.0.0", "reports", false, nil, "")
-	err = os.MkdirAll(dibReport.GetJunitReportDir(), 0o755)
+	err = os.MkdirAll(dibReport.GetJunitReportDir(), 0o750)
 	require.NoError(t, err)
 
 	opts := types.RunTestOptions{

--- a/pkg/kaniko/context_remote.go
+++ b/pkg/kaniko/context_remote.go
@@ -84,7 +84,7 @@ func createArchive(buildContextDir string, tarGzPath string) error {
 	}
 
 	// Create the .tar.gz file.
-	tarGzFile, err := os.Create(tarGzPath)
+	tarGzFile, err := os.Create(tarGzPath) //nolint:gosec
 	if err != nil {
 		return fmt.Errorf("can't create tar.gz file %s: %w", tarGzPath, err)
 	}

--- a/pkg/kaniko/context_remote_internal_test.go
+++ b/pkg/kaniko/context_remote_internal_test.go
@@ -1,3 +1,4 @@
+//nolint:gosec
 package kaniko
 
 import (

--- a/pkg/kaniko/context_remote_test.go
+++ b/pkg/kaniko/context_remote_test.go
@@ -55,8 +55,7 @@ func Test_RemoteContextProvider_UploadsBuildContext(t *testing.T) {
 
 	// Create the build context directory
 	opts := provideDefaultBuildOptions()
-	err := os.Mkdir(opts.Context, 0o750)
-	require.NoError(t, err)
+	require.NoError(t, os.Mkdir(opts.Context, 0o750))
 	t.Cleanup(func() {
 		_ = os.Remove(opts.Context)
 	})

--- a/pkg/kaniko/executor_kubernetes_test.go
+++ b/pkg/kaniko/executor_kubernetes_test.go
@@ -142,8 +142,8 @@ spec:
 				assert.Len(t, pod.Spec.Volumes, 1)
 				volume := pod.Spec.Volumes[0]
 				assert.Equal(t, dockerSecretName, volume.Name)
-				assert.Equal(t, dockerSecretName, volume.VolumeSource.Secret.SecretName)
-				assert.Equal(t, int32(420), *volume.VolumeSource.Secret.DefaultMode)
+				assert.Equal(t, dockerSecretName, volume.Secret.SecretName)
+				assert.Equal(t, int32(420), *volume.Secret.DefaultMode)
 
 				// Container assertions
 				container := pod.Spec.Containers[0]

--- a/pkg/kaniko/s3.go
+++ b/pkg/kaniko/s3.go
@@ -29,7 +29,7 @@ func NewS3Uploader(cfg aws.Config, bucket string) *S3Uploader {
 
 // UploadFile uploads a file to an AWS S3 bucket.
 func (u S3Uploader) UploadFile(filePath string, targetPath string) error {
-	file, err := os.Open(filePath)
+	file, err := os.Open(filePath) //nolint:gosec
 	if err != nil {
 		return fmt.Errorf("can't open file %s: %w", filePath, err)
 	}

--- a/pkg/mock/builder.go
+++ b/pkg/mock/builder.go
@@ -24,7 +24,7 @@ const ReportsDir = "tests/mock-reports"
 
 //nolint:musttag
 func (e *Builder) Build(opts types.ImageBuilderOpts) error {
-	if err := os.MkdirAll(path.Join(ReportsDir, e.ID), 0o755); err != nil && !os.IsExist(err) {
+	if err := os.MkdirAll(path.Join(ReportsDir, e.ID), 0o750); err != nil && !os.IsExist(err) {
 		return fmt.Errorf("failed to create mock-reports directory: %w", err)
 	}
 

--- a/pkg/ratelimit/channel.go
+++ b/pkg/ratelimit/channel.go
@@ -1,15 +1,15 @@
 package ratelimit
 
+// ChannelRateLimiter is an implementation of RateLimiter based on a single channel.
+type ChannelRateLimiter struct {
+	limiter chan struct{}
+}
+
 // NewChannelRateLimiter returns an instance of ChannelRateLimiter.
 func NewChannelRateLimiter(concurrency int) *ChannelRateLimiter {
 	return &ChannelRateLimiter{
 		limiter: make(chan struct{}, concurrency),
 	}
-}
-
-// ChannelRateLimiter is an implementation of RateLimiter based on a single channel.
-type ChannelRateLimiter struct {
-	limiter chan struct{}
 }
 
 // Acquire holds on the channel until it can send a message.

--- a/pkg/report/template.go
+++ b/pkg/report/template.go
@@ -65,7 +65,7 @@ func Generate(dibReport *Report, dag *dag.DAG) error {
 
 	logger.Infof("Generating HTML report in the %s folder...", dibReport.GetRootDir())
 
-	if err := os.MkdirAll(dibReport.GetRootDir(), 0o755); err != nil && !os.IsExist(err) {
+	if err := os.MkdirAll(dibReport.GetRootDir(), 0o750); err != nil && !os.IsExist(err) {
 		return fmt.Errorf("unable to create report folder: %w", err)
 	}
 
@@ -94,7 +94,7 @@ func copyAssetsFiles(dibReport *Report) error {
 		}
 
 		if itemEntry.IsDir() {
-			return os.MkdirAll(path.Join(dibReport.GetRootDir(), itemPath), 0o755)
+			return os.MkdirAll(path.Join(dibReport.GetRootDir(), itemPath), 0o750)
 		}
 
 		data, err := fs.ReadFile(assetsFS, itemPath)
@@ -190,7 +190,7 @@ func parseGossLogs(dibReport *Report) map[string]any {
 		}
 
 		gossTestLogsFile := fmt.Sprintf("%s/junit-%s.xml", dibReport.GetJunitReportDir(), buildReport.Image.ShortName)
-		rawGossTestLogs, err := os.ReadFile(gossTestLogsFile)
+		rawGossTestLogs, err := os.ReadFile(gossTestLogsFile) //nolint:gosec
 		if err != nil {
 			gossTestsLogsData[buildReport.Image.ShortName] = err.Error()
 			continue
@@ -220,7 +220,7 @@ func parseTrivyReports(dibReport *Report) map[string]any {
 		}
 
 		trivyScanFile := fmt.Sprintf("%s/%s.json", dibReport.GetTrivyReportDir(), buildReport.Image.ShortName)
-		rawTrivyReport, err := os.ReadFile(trivyScanFile)
+		rawTrivyReport, err := os.ReadFile(trivyScanFile) //nolint:gosec
 		if err != nil {
 			trivyScanData[buildReport.Image.ShortName] = err.Error()
 			continue

--- a/pkg/trivy/executor_kubernetes_test.go
+++ b/pkg/trivy/executor_kubernetes_test.go
@@ -145,8 +145,8 @@ spec:
 				assert.Len(t, pod.Spec.Volumes, 1)
 				volume := pod.Spec.Volumes[0]
 				assert.Equal(t, dockerSecretName, volume.Name)
-				assert.Equal(t, dockerSecretName, volume.VolumeSource.Secret.SecretName)
-				assert.Equal(t, int32(420), *volume.VolumeSource.Secret.DefaultMode)
+				assert.Equal(t, dockerSecretName, volume.Secret.SecretName)
+				assert.Equal(t, int32(420), *volume.Secret.DefaultMode)
 
 				// Container assertions
 				container := pod.Spec.Containers[0]

--- a/pkg/trivy/runner.go
+++ b/pkg/trivy/runner.go
@@ -77,12 +77,12 @@ func (b TestRunner) RunTest(opts types.RunTestOptions) error {
 		opts.ImageReference,
 	}
 
-	err := os.MkdirAll(opts.ReportTrivyDir, 0o755)
+	err := os.MkdirAll(opts.ReportTrivyDir, 0o750)
 	if err != nil {
 		return fmt.Errorf("failed to create directory %s: %w", opts.ReportTrivyDir, err)
 	}
 
-	scanError := b.Executor.Execute(context.Background(), &stdout, args...)
+	scanError := b.Execute(context.Background(), &stdout, args...)
 	if err := b.exportTrivyReport(opts, stdout.String()); err != nil {
 		return fmt.Errorf("trivy tests failed, could not export scan report: %w", err)
 	}

--- a/pkg/trivy/runner_test.go
+++ b/pkg/trivy/runner_test.go
@@ -1,3 +1,4 @@
+//nolint:gosec
 package trivy_test
 
 import (


### PR DESCRIPTION
- Use golangci-lint v2.1.2 with our new .golangci.yml config file from radiofrance/lint-config v1.1.0
- Apply the needed fixes
- Improve the renovate config, so it will bump golangci-lint and radiofrance/lint-config in one PR