### PR TITLE
refact: package `cmd`

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -4,7 +4,7 @@ before:
   hooks:
     - go mod tidy
 builds:
-  - main: ./cmd/
+  - main: .
     # Custom ldflags.
     # Default: '-s -w -X main.version={{.Version}} -X main.commit={{.Commit}} -X main.date={{.Date}} -X main.builtBy=goreleaser'
     ldflags:

--- a/Makefile
+++ b/Makefile
@@ -23,7 +23,7 @@ install: ## Generate binary and copy it to $GOPATH/bin (equivalent to go install
 	goreleaser build --clean --snapshot --single-target -o $(GOPATH)/bin/dib
 
 build: ## Build the CLI binary.
-	CGO_ENABLED=0 GOOS=$(GOOS) $(GO) build -o ./dist/dib ./cmd
+	CGO_ENABLED=0 GOOS=$(GOOS) $(GO) build -o ./dist/dib .
 
 docs: build
 	./dist/dib docgen

--- a/cmd/build_internal_test.go
+++ b/cmd/build_internal_test.go
@@ -1,4 +1,4 @@
-package main
+package cmd
 
 import (
 	"testing"

--- a/cmd/docgen.go
+++ b/cmd/docgen.go
@@ -1,4 +1,4 @@
-package main
+package cmd
 
 import (
 	"fmt"
@@ -18,33 +18,28 @@ title: "%s"
 
 var cmdDocPath string
 
-var docgenCmd = &cobra.Command{
-	Use:    "docgen",
-	Short:  "Generate the documentation for the CLI commands.",
-	Hidden: true,
-	RunE:   docgenCmdRun,
-}
-
-func init() {
-	docgenCmd.Flags().StringVar(&cmdDocPath, "path", "./docs/cmd",
+func docgenCommand() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:    "docgen",
+		Short:  "Generate the documentation for the CLI commands.",
+		Hidden: true,
+		RunE:   docgenAction,
+	}
+	cmd.Flags().StringVar(&cmdDocPath, "path", "./docs/cmd",
 		"path to write the generated documentation to")
 
-	rootCmd.AddCommand(docgenCmd)
+	return cmd
 }
 
-func docgenCmdRun(_ *cobra.Command, _ []string) error {
+func docgenAction(_ *cobra.Command, _ []string) error {
 	if err := os.MkdirAll(cmdDocPath, 0o750); err != nil {
 		return err
 	}
 
-	err := doc.GenMarkdownTreeCustom(rootCmd, cmdDocPath, frontmatterPrepender, linkHandler)
-	if err != nil {
-		return err
-	}
-	return nil
+	return doc.GenMarkdownTreeCustom(rootCmd, cmdDocPath, filePrepender, linkHandler)
 }
 
-func frontmatterPrepender(filename string) string {
+func filePrepender(filename string) string {
 	name := filepath.Base(filename)
 	base := strings.TrimSuffix(name, path.Ext(name))
 	title := strings.ReplaceAll(base, "_", " ")

--- a/cmd/list.go
+++ b/cmd/list.go
@@ -11,7 +11,7 @@ import (
 )
 
 func listCommand() *cobra.Command {
-	longHelp := `Command list provide different ways to print the list of all Docker images managed by dib.
+	const longHelp = `Command list provide different ways to print the list of all Docker images managed by dib.
 
 The output can be customized with the --output flag :
 • console (default output)

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -1,5 +1,0 @@
-package main
-
-func main() {
-	Execute()
-}

--- a/cmd/version.go
+++ b/cmd/version.go
@@ -1,4 +1,5 @@
-package main
+//nolint:forbidigo
+package cmd
 
 import (
 	"fmt"
@@ -17,34 +18,29 @@ var (
 	builtBy = "unknown"
 )
 
-// versionCmd represents the version command.
-//
-//nolint:forbidigo
-var versionCmd = &cobra.Command{
-	Use:   "version",
-	Short: "print current dib version",
-	Run: func(_ *cobra.Command, _ []string) {
-		goVersion := "unknown"
-		buildInfo, available := debug.ReadBuildInfo()
-		if available {
-			goVersion = buildInfo.GoVersion
-		}
+func versionCommand() *cobra.Command {
+	return &cobra.Command{
+		Use:   "version",
+		Short: "print current dib version",
+		Run: func(_ *cobra.Command, _ []string) {
+			goVersion := "unknown"
+			buildInfo, available := debug.ReadBuildInfo()
+			if available {
+				goVersion = buildInfo.GoVersion
+			}
 
-		fmt.Printf("version: v%s\n", version)
-		fmt.Printf("build on %s/%s by %s at %s with %s (from commit %s)\n",
-			runtime.GOOS,
-			runtime.GOARCH,
-			builtBy,
-			date,
-			goVersion,
-			commit,
-		)
-		if available && buildInfo.Main.Sum != "" {
-			fmt.Printf("module version: %s, checksum: %q\n", buildInfo.Main.Version, buildInfo.Main.Sum)
-		}
-	},
-}
-
-func init() {
-	rootCmd.AddCommand(versionCmd)
+			fmt.Printf("version: v%s\n", version)
+			fmt.Printf("build on %s/%s by %s at %s with %s (from commit %s)\n",
+				runtime.GOOS,
+				runtime.GOARCH,
+				builtBy,
+				date,
+				goVersion,
+				commit,
+			)
+			if available && buildInfo.Main.Sum != "" {
+				fmt.Printf("module version: %s, checksum: %q\n", buildInfo.Main.Version, buildInfo.Main.Sum)
+			}
+		},
+	}
 }

--- a/cmd/version.go
+++ b/cmd/version.go
@@ -22,25 +22,27 @@ func versionCommand() *cobra.Command {
 	return &cobra.Command{
 		Use:   "version",
 		Short: "print current dib version",
-		Run: func(_ *cobra.Command, _ []string) {
-			goVersion := "unknown"
-			buildInfo, available := debug.ReadBuildInfo()
-			if available {
-				goVersion = buildInfo.GoVersion
-			}
+		Run:   versionAction,
+	}
+}
 
-			fmt.Printf("version: v%s\n", version)
-			fmt.Printf("build on %s/%s by %s at %s with %s (from commit %s)\n",
-				runtime.GOOS,
-				runtime.GOARCH,
-				builtBy,
-				date,
-				goVersion,
-				commit,
-			)
-			if available && buildInfo.Main.Sum != "" {
-				fmt.Printf("module version: %s, checksum: %q\n", buildInfo.Main.Version, buildInfo.Main.Sum)
-			}
-		},
+func versionAction(*cobra.Command, []string) {
+	goVersion := "unknown"
+	buildInfo, available := debug.ReadBuildInfo()
+	if available {
+		goVersion = buildInfo.GoVersion
+	}
+
+	fmt.Printf("version: v%s\n", version)
+	fmt.Printf("build on %s/%s by %s at %s with %s (from commit %s)\n",
+		runtime.GOOS,
+		runtime.GOARCH,
+		builtBy,
+		date,
+		goVersion,
+		commit,
+	)
+	if available && buildInfo.Main.Sum != "" {
+		fmt.Printf("module version: %s, checksum: %q\n", buildInfo.Main.Version, buildInfo.Main.Sum)
 	}
 }

--- a/main.go
+++ b/main.go
@@ -1,0 +1,7 @@
+package main
+
+import "github.com/radiofrance/dib/cmd"
+
+func main() {
+	cmd.Execute()
+}


### PR DESCRIPTION
The goal of this PR is to simplify and standardize the `./cmd` package, using best practices from Cobra and Viper:
- new `main.go` file at the root of the project
- files inside `./cmd` are now linked to package `cmd` instead of `main`
- sub-commands are now added in the `init` function of `rootCmd` to simplifies the command linking architecture