### PR TITLE
Add support for rootless mode in buildkit

### DIFF
--- a/pkg/buildkit/buildkitutil.go
+++ b/pkg/buildkit/buildkitutil.go
@@ -5,7 +5,8 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
-
+	
+	"github.com/radiofrance/dib/pkg/rootlessutil"
 	"github.com/radiofrance/dib/internal/logger"
 )
 
@@ -15,7 +16,11 @@ const (
 )
 
 func getHint() string {
-	return "buildctl` needs to be installed and `buildkitd` needs to be running, see https://github.com/moby/buildkit"
+	hint := "`buildctl` needs to be installed and `buildkitd` needs to be running, see https://github.com/moby/buildkit\n"
+	if rootlessutil.IsRootless() {
+		hint += "For rootless mode, use `rootlesskit buildkitd` (see https://github.com/rootless-containers/rootlesskit/)."
+	}
+	return hint
 }
 
 func BuildctlBinary() (string, error) {

--- a/pkg/buildkit/buildkitutil_linux.go
+++ b/pkg/buildkit/buildkitutil_linux.go
@@ -1,7 +1,12 @@
 package buildkit
 
+import "github.com/radiofrance/dib/pkg/rootlessutil"
+
 func getRuntimeVariableDataDir() string {
 	// Per Linux Foundation "Filesystem Hierarchy Standard" version 3.0 section 3.15.
 	// Under version 2.3, this was "/var/run".
+	if rootlessutil.IsRootless() {
+		return rootlessutil.XDGRuntimeDir()
+	}
 	return "/run"
 }

--- a/pkg/rootlessutil/rootless_linux.go
+++ b/pkg/rootlessutil/rootless_linux.go
@@ -1,0 +1,20 @@
+package rootlessutil
+
+import (
+	"fmt"
+	"os"
+)
+
+func IsRootless() bool {
+	return os.Geteuid() != 0
+}
+
+// https://specifications.freedesktop.org/basedir-spec/latest/
+func XDGRuntimeDir() string {
+	// XDG_RUNTIME_DIR is an environment variable specifying a user-specific directory for runtime files (e.g socket..)
+	if xrd := os.Getenv("XDG_RUNTIME_DIR"); xrd != "" {
+		return xrd
+	}
+	// Fall back to "/run/user/<euid>".
+	return fmt.Sprintf("/run/user/%d", os.Geteuid())
+}


### PR DESCRIPTION
This pull request introduces support for rootless mode in BuildKit utilities by leveraging a new `rootlessutil` package. 
### Rootless mode support:

* [`pkg/buildkit/buildkitutil.go`](diffhunk://#diff-7be5906ef3f071801a35231bdbedfe635bb44e894c5a7ec2b56ae06655f74f2eL18-R23): Updated the `getHint` function to include additional instructions for rootless mode, advising the use of `rootlesskit buildkitd` when `rootlessutil.IsRootless()` is true.
* [`pkg/buildkit/buildkitutil_linux.go`](diffhunk://#diff-d07efb2e35dfd2ec6a11cc629cdfcd02922d74b90edaa0c839f70a7e3add299bR3-R10): Modified the `getRuntimeVariableDataDir` function to return the `XDGRuntimeDir` when running in rootless mode, as determined by `rootlessutil.IsRootless()`.