### PR TITLE
Add Kubernetes executor for Buildkit Backend

### DIFF
--- a/pkg/buildkit/builder.go
+++ b/pkg/buildkit/builder.go
@@ -1,40 +1,169 @@
 package buildkit
 
 import (
+	"context"
+	"errors"
+	"fmt"
 	"path/filepath"
 
+	"github.com/aws/aws-sdk-go-v2/config"
 	"github.com/distribution/reference"
+	"github.com/radiofrance/dib/internal/logger"
 	"github.com/radiofrance/dib/pkg/exec"
+	"github.com/radiofrance/dib/pkg/executor"
+	k8sutils "github.com/radiofrance/dib/pkg/kubernetes"
 	"github.com/radiofrance/dib/pkg/strutil"
 	"github.com/radiofrance/dib/pkg/types"
+	"github.com/radiofrance/kubecli"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	"k8s.io/utils/ptr"
 )
 
-type Builder struct {
-	executor       exec.Executor
+// ContextProvider provides a layer of abstraction for different build context sources.
+type ContextProvider interface {
+	// PrepareContext allows to do some operations on the build context before the executor runs,
+	// like moving it to a remote location in order to be accessible by remote executors.
+	// It must return a URL compatible with Buildkit's `--context` flag.
+	PrepareContext(opts types.ImageBuilderOpts) (string, error)
+}
+
+type bkShellExecutor struct {
+	shellExecutor  executor.ShellExecutor
 	buildctlBinary string
 }
 
+type bkKubernetesExecutor struct {
+	KubernetesExecutor executor.KubernetesExecutor
+	buildctlBinary     string
+	dockerConfigSecret string             // Name of the secret containing the docker config used by Buildkit (required).
+	podConfig          k8sutils.PodConfig // The default pod configuration used to run Buildkit builds.
+}
+type Builder struct {
+	bkShellExecutor      bkShellExecutor
+	bkKubernetesExecutor bkKubernetesExecutor
+	contextProvider      ContextProvider
+}
+
+// Config holds the configuration for the Buildkit build backend.
+type Config struct {
+	Context struct {
+		S3 struct {
+			Bucket string `mapstructure:"bucket"`
+			Region string `mapstructure:"region"`
+		} `mapstructure:"s3"`
+	} `mapstructure:"context"`
+	Executor struct {
+		Kubernetes struct {
+			Namespace           string   `mapstructure:"namespace"`
+			Image               string   `mapstructure:"image"`
+			DockerConfigSecret  string   `mapstructure:"docker_config_secret"`
+			ImagePullSecrets    []string `mapstructure:"image_pull_secrets"`
+			EnvSecrets          []string `mapstructure:"env_secrets"`
+			ContainerOverride   string   `mapstructure:"container_override"`
+			PodTemplateOverride string   `mapstructure:"pod_template_override"`
+		} `mapstructure:"kubernetes"`
+	} `mapstructure:"executor"`
+}
+
 // NewBuilder creates a new instance of Builder.
-func NewBKBuilder(exec exec.Executor, binary string) (*Builder, error) {
+func NewBKBuilder(cfg Config, workingDir string, binary string, localOnly bool) (*Builder, error) {
+	var (
+		err             error
+		k8sExecutor     executor.KubernetesExecutor
+		shellExecutor   executor.ShellExecutor
+		contextProvider ContextProvider
+	)
+
+	if localOnly {
+		shellExecutor = exec.NewShellExecutor(workingDir, nil)
+		contextProvider = NewLocalContextProvider()
+	} else {
+		k8sExecutor, err = createBuildkitKubernetesExecutor()
+		if err != nil {
+			logger.Fatalf("cannot create buidkit kubernetes executor: %v", err)
+		}
+
+		awsCfg, err := config.LoadDefaultConfig(context.Background(),
+			config.WithRegion(cfg.Context.S3.Region))
+		if err != nil {
+			logger.Fatalf("cannot load AWS config: %v", err)
+		}
+		s3 := NewS3Uploader(awsCfg, cfg.Context.S3.Bucket)
+		contextProvider = NewRemoteContextProvider(s3)
+	}
+
 	return &Builder{
-		executor:       exec,
-		buildctlBinary: binary,
+		bkShellExecutor: bkShellExecutor{
+			shellExecutor,
+			binary,
+		},
+		bkKubernetesExecutor: bkKubernetesExecutor{
+			KubernetesExecutor: k8sExecutor,
+			buildctlBinary:     binary,
+			dockerConfigSecret: cfg.Executor.Kubernetes.DockerConfigSecret,
+			podConfig: k8sutils.PodConfig{
+				Namespace:     cfg.Executor.Kubernetes.Namespace,
+				NameGenerator: k8sutils.UniquePodName("buildkit-dib"),
+				Labels: map[string]string{
+					"app.kubernetes.io/managed-by": "dib",
+				},
+				Image:            cfg.Executor.Kubernetes.Image,
+				ImagePullSecrets: cfg.Executor.Kubernetes.ImagePullSecrets,
+				EnvSecrets:       cfg.Executor.Kubernetes.EnvSecrets,
+				Env: map[string]string{
+					"AWS_REGION": cfg.Context.S3.Region,
+					"container":  "kube", // Fix for https://github.com/GoogleContainerTools/kaniko/issues/1542
+				},
+				PodOverride:       cfg.Executor.Kubernetes.PodTemplateOverride,
+				ContainerOverride: cfg.Executor.Kubernetes.ContainerOverride,
+			},
+		},
+		contextProvider: contextProvider,
 	}, nil
 }
 
 // Build the image using the Buildkit backend.
 func (b Builder) Build(opts types.ImageBuilderOpts) error {
+	var err error
+
+	opts.Context, err = b.contextProvider.PrepareContext(opts)
+	if err != nil {
+		return fmt.Errorf("cannot prepare buildkit build context: %w", err)
+	}
 	buildctlArgs, err := generateBuildctlArgs(opts)
 	if err != nil {
 		return err
 	}
-
-	// Currently, we only support writing to stdout. In the future, this can be improved to support custom stdio.
-	if err := b.executor.ExecuteStdout(b.buildctlBinary, buildctlArgs...); err != nil {
-		return err
+	// `shellExecutor` or `kubernetesExecutor` are mutually exclusive.
+	if b.bkShellExecutor.shellExecutor != nil {
+		//nolint:lll
+		if err := b.bkShellExecutor.shellExecutor.ExecuteStdout(b.bkShellExecutor.buildctlBinary, buildctlArgs...); err != nil {
+			return err
+		}
+	} else {
+		pod, err := buildPod(b.bkKubernetesExecutor.dockerConfigSecret, b.bkKubernetesExecutor.podConfig, buildctlArgs)
+		if err != nil {
+			return err
+		}
+		//nolint:lll
+		if err := b.bkKubernetesExecutor.KubernetesExecutor.ApplyWithWriters(context.Background(), opts.LogOutput, opts.LogOutput, pod, "buildkit"); err != nil {
+			return err
+		}
 	}
 
 	return nil
+}
+
+func createBuildkitKubernetesExecutor() (*exec.KubernetesExecutor, error) {
+	k8sClient, err := kubecli.New("")
+	if err != nil {
+		return nil, fmt.Errorf("could not get kube client from context: %w", err)
+	}
+
+	executor := exec.NewKubernetesExecutor(k8sClient.ClientSet)
+	return executor, nil
 }
 
 func generateBuildctlArgs(opts types.ImageBuilderOpts) ([]string, error) {
@@ -59,34 +188,42 @@ func generateBuildctlArgs(opts types.ImageBuilderOpts) ([]string, error) {
 
 	buildctlArgs := buildctlBaseArgs(opts.BuildkitHost)
 
+	var contextArg string
+	if opts.LocalOnly {
+		contextArg = "--local=context=" + opts.Context
+	} else {
+		// We use a pre-signed URL to securely fetch the context from a remote source, ensuring proper access control.
+		contextArg = "--opt=context=" + opts.Context
+	}
 	buildctlArgs = append(buildctlArgs, []string{
 		"build",
 		"--progress=" + opts.Progress,
 		"--frontend=dockerfile.v0",
-		"--local=context=" + opts.Context,
+		contextArg,
 		"--output=" + output,
 	}...)
 
-	// Set the directory and filename for the Dockerfile,
-	// as the Dockerfile path may differ from the build context path.
-	dir := opts.Context
-	file := defaultDockerfileName
-	if opts.File != "" {
-		dir, file = filepath.Split(opts.File)
+	if opts.LocalOnly {
+		// Set the directory and filename for the Dockerfile,
+		// as the Dockerfile path may differ from the build context path.
+		dir := opts.Context
+		file := defaultDockerfileName
+		if opts.File != "" {
+			dir, file = filepath.Split(opts.File)
 
-		if dir == "" {
-			dir = "."
+			if dir == "" {
+				dir = "."
+			}
 		}
-	}
 
-	var err error
-	dir, file, err = buildKitFile(dir, file)
-	if err != nil {
-		return nil, err
+		var err error
+		dir, file, err = buildKitFile(dir, file)
+		if err != nil {
+			return nil, err
+		}
+		buildctlArgs = append(buildctlArgs, "--local=dockerfile="+dir)
+		buildctlArgs = append(buildctlArgs, "--opt=filename="+file)
 	}
-
-	buildctlArgs = append(buildctlArgs, "--local=dockerfile="+dir)
-	buildctlArgs = append(buildctlArgs, "--opt=filename="+file)
 
 	// The target option specifies the build stage to build.
 	if opts.Target != "" {
@@ -102,4 +239,173 @@ func generateBuildctlArgs(opts types.ImageBuilderOpts) ([]string, error) {
 	}
 
 	return buildctlArgs, nil
+}
+
+func buildPod(dockerConfigSecret string, podConfig k8sutils.PodConfig, args []string) (*corev1.Pod, error) {
+	logger.Infof("Building image with Buildkit kubernetes executor")
+	if dockerConfigSecret == "" {
+		return nil, errors.New("the DockerConfigSecret option is required")
+	}
+
+	podName := podConfig.Name
+	if podConfig.NameGenerator != nil {
+		podName = podConfig.NameGenerator()
+	}
+	containerName := "buildkit"
+
+	labels := map[string]string{
+		"app.kubernetes.io/name":      "buildkit",
+		"app.kubernetes.io/component": "build-pod",
+		"app.kubernetes.io/instance":  podName,
+	}
+	// Merge the default labels with those provided in the options.
+	for k, v := range podConfig.Labels {
+		labels[k] = v
+	}
+
+	objectMeta := metav1.ObjectMeta{
+		Name:      podName,
+		Namespace: podConfig.Namespace,
+		Labels:    labels,
+	}
+
+	var imagePullSecrets []corev1.LocalObjectReference
+	for _, secretName := range podConfig.ImagePullSecrets {
+		imagePullSecrets = append(imagePullSecrets, corev1.LocalObjectReference{
+			Name: secretName,
+		})
+	}
+
+	var envVars []corev1.EnvVar
+	for k, v := range podConfig.Env {
+		envVars = append(envVars, corev1.EnvVar{
+			Name:  k,
+			Value: v,
+		})
+	}
+
+	var envFrom []corev1.EnvFromSource
+	for _, secretName := range podConfig.EnvSecrets {
+		envFrom = append(envFrom, corev1.EnvFromSource{
+			SecretRef: &corev1.SecretEnvSource{
+				LocalObjectReference: corev1.LocalObjectReference{
+					Name: secretName,
+				},
+			},
+		})
+	}
+
+	container := corev1.Container{
+		Name:            containerName,
+		Image:           podConfig.Image,
+		ImagePullPolicy: corev1.PullIfNotPresent,
+		Args:            args,
+		EnvFrom:         envFrom,
+		Env: append([]corev1.EnvVar{
+			{
+				Name:  "DOCKER_CONFIG",
+				Value: "/buildkit/.docker",
+			},
+		}, envVars...),
+		VolumeMounts: []corev1.VolumeMount{
+			{
+				Name:      dockerConfigSecret,
+				MountPath: "/buildkit/.docker",
+				ReadOnly:  true,
+			},
+		},
+		LivenessProbe: &corev1.Probe{
+			ProbeHandler: corev1.ProbeHandler{
+				Exec: &corev1.ExecAction{
+					Command: []string{"buildctl", "debug", "workers"},
+				},
+			},
+			InitialDelaySeconds: 5,
+			PeriodSeconds:       30,
+		},
+		ReadinessProbe: &corev1.Probe{
+			ProbeHandler: corev1.ProbeHandler{
+				Exec: &corev1.ExecAction{
+					Command: []string{"buildctl", "debug", "workers"},
+				},
+			},
+			InitialDelaySeconds: 5,
+			PeriodSeconds:       30,
+		},
+		SecurityContext: &corev1.SecurityContext{
+			RunAsUser:  ptr.To[int64](RemoteUserId),
+			RunAsGroup: ptr.To[int64](RemoteGroupId),
+			// Needs Kubernetes >= 1.19
+			SeccompProfile: &corev1.SeccompProfile{
+				Type: corev1.SeccompProfileTypeUnconfined,
+			},
+			// Needs Kubernetes >= 1.30
+			// https://github.com/rootless-containers/rootlesskit/pull/421
+			AppArmorProfile: &corev1.AppArmorProfile{
+				Type: corev1.AppArmorProfileTypeUnconfined,
+			},
+		},
+	}
+	err := k8sutils.MergeObjectWithYaml(&container, podConfig.ContainerOverride)
+	if err != nil {
+		return nil, err
+	}
+
+	pod := corev1.Pod{
+		ObjectMeta: objectMeta,
+		Spec: corev1.PodSpec{
+			ImagePullSecrets: imagePullSecrets,
+			Containers: []corev1.Container{
+				container,
+			},
+			RestartPolicy: corev1.RestartPolicyNever,
+			Affinity: &corev1.Affinity{
+				PodAntiAffinity: &corev1.PodAntiAffinity{
+					PreferredDuringSchedulingIgnoredDuringExecution: []corev1.WeightedPodAffinityTerm{
+						{
+							PodAffinityTerm: corev1.PodAffinityTerm{
+								LabelSelector: &metav1.LabelSelector{
+									MatchLabels: map[string]string{
+										"app.kubernetes.io/name":      "buildkit",
+										"app.kubernetes.io/component": "build-pod",
+									},
+								},
+								TopologyKey: "kubernetes.io/hostname",
+							},
+							Weight: 50,
+						},
+						{
+							PodAffinityTerm: corev1.PodAffinityTerm{
+								LabelSelector: &metav1.LabelSelector{
+									MatchLabels: map[string]string{
+										"app.kubernetes.io/name":      "buildkit",
+										"app.kubernetes.io/component": "build-pod",
+									},
+								},
+								TopologyKey: "topology.kubernetes.io/zone",
+							},
+							Weight: 100,
+						},
+					},
+				},
+			},
+			Volumes: []corev1.Volume{
+				{
+					Name: dockerConfigSecret,
+					VolumeSource: corev1.VolumeSource{
+						Secret: &corev1.SecretVolumeSource{
+							SecretName:  dockerConfigSecret,
+							DefaultMode: ptr.To[int32](420),
+						},
+					},
+				},
+			},
+		},
+	}
+	err = k8sutils.MergeObjectWithYaml(&pod, podConfig.PodOverride)
+	if err != nil {
+		return nil, err
+	}
+
+	return &pod, nil
 }

--- a/pkg/buildkit/buildkitutil.go
+++ b/pkg/buildkit/buildkitutil.go
@@ -13,6 +13,10 @@ import (
 const (
 	// defaultDockerfileName is the Default filename, read by dib build.
 	defaultDockerfileName string = "Dockerfile"
+
+	// RemoteUserId and RemoteGroupId represent the user ID and group ID that the Kubernetes container will run with.
+	RemoteUserId  = 1000
+	RemoteGroupId = 1000
 )
 
 func getHint() string {
@@ -88,4 +92,8 @@ func buildKitFile(dir, inputfile string) (string, string, error) {
 		return "", "", err
 	}
 	return absDir, file, nil
+}
+
+func GetRemoteBuildkitHostAddress(uid int) string {
+	return "unix://" + filepath.Join("/run/user", fmt.Sprintf("%d", uid), "buildkit/buildkitd.sock")
 }

--- a/pkg/buildkit/context_local.go
+++ b/pkg/buildkit/context_local.go
@@ -1,0 +1,19 @@
+package buildkit
+
+import (
+	"github.com/radiofrance/dib/pkg/types"
+)
+
+// LocalContextProvider provides a local build context.
+type LocalContextProvider struct{}
+
+// NewLocalContextProvider creates a new instance of LocalContextProvider.
+func NewLocalContextProvider() *LocalContextProvider {
+	return &LocalContextProvider{}
+}
+
+// PrepareContext returns the local build context path without performing any additional operations.
+// Since the context is already available locally, it simply returns the context path from the provided options.
+func (c LocalContextProvider) PrepareContext(opts types.ImageBuilderOpts) (string, error) {
+	return opts.Context, nil
+}

--- a/pkg/buildkit/context_local_test.go
+++ b/pkg/buildkit/context_local_test.go
@@ -1,0 +1,56 @@
+//nolint:testpackage
+package buildkit
+
+import (
+	"testing"
+
+	"github.com/radiofrance/dib/pkg/types"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestPrepareLocalContext(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name     string
+		opts     types.ImageBuilderOpts
+		expected string
+		err      error
+	}{
+		{
+			name: "valid context",
+			opts: types.ImageBuilderOpts{
+				Context: "valid-context",
+			},
+			expected: "valid-context",
+			err:      nil,
+		},
+		{
+			name: "empty context",
+			opts: types.ImageBuilderOpts{
+				Context: "",
+			},
+			expected: "",
+			err:      nil,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			provider := LocalContextProvider{}
+			result, err := provider.PrepareContext(tt.opts)
+			assert.Equal(t, tt.expected, result)
+			require.ErrorIs(t, err, tt.err)
+		})
+	}
+}
+
+func TestNewLocalContextProvider(t *testing.T) {
+	t.Parallel()
+
+	provider := NewLocalContextProvider()
+	assert.NotNil(t, provider)
+}

--- a/pkg/buildkit/context_remote.go
+++ b/pkg/buildkit/context_remote.go
@@ -1,0 +1,167 @@
+package buildkit
+
+import (
+	"archive/tar"
+	"compress/gzip"
+	"fmt"
+	"io"
+	"io/fs"
+	"os"
+	"path"
+	"path/filepath"
+	"strings"
+
+	"github.com/radiofrance/dib/internal/logger"
+	"github.com/radiofrance/dib/pkg/types"
+)
+
+// FileUploader is an interface for uploading files to a remote location.
+// It basically abstracts storage services such as AWS S3, GCS, etc...
+type FileUploader interface {
+	UploadFile(filePath string, targetPath string) error
+	PresignedURL(targetPath string) (string, error)
+}
+
+// RemoteContextProvider allows to upload the build context to a remote location.
+type RemoteContextProvider struct {
+	uploader FileUploader
+}
+
+// NewRemoteContextProvider creates a new instance of RemoteContextProvider.
+func NewRemoteContextProvider(uploader FileUploader) *RemoteContextProvider {
+	return &RemoteContextProvider{uploader}
+}
+
+// PrepareContext is responsible for creating an archive of the build context directory
+// and uploading it to the remote location where the buildkit build pod can retrieve it later.
+func (c RemoteContextProvider) PrepareContext(opts types.ImageBuilderOpts) (string, error) {
+	tagParts := strings.Split(opts.Tags[0], ":")
+	shortName := path.Base(tagParts[0])
+	remoteDir := fmt.Sprintf("buildkit/%s", shortName)
+	filename := fmt.Sprintf("context-buildkit-%s-%s.tar.gz", shortName, tagParts[1])
+
+	tarGzPath := path.Join(opts.Context, filename)
+	if err := createArchive(opts.Context, tarGzPath); err != nil {
+		return "", err
+	}
+
+	targetPath := fmt.Sprintf("%s/%s", remoteDir, filename)
+	if err := uploadBuildContext(c.uploader, tarGzPath, targetPath); err != nil {
+		return "", err
+	}
+
+	return c.uploader.PresignedURL(targetPath)
+}
+
+// createArchive builds an archive containing all the files in the build context.
+func createArchive(buildContextDir string, tarGzPath string) error {
+	logger.Infof("Creating docker build-context for buildkit")
+
+	// Check if the build context directory exists.
+	if _, err := os.Stat(buildContextDir); os.IsNotExist(err) {
+		return fmt.Errorf("can't access directory %q: it doesn't exist", buildContextDir)
+	}
+
+	// Walk through the build context directory, and collect all the files to be archived.
+	files := make(map[string]os.FileInfo)
+	if err := filepath.Walk(buildContextDir, func(filePath string, info os.FileInfo, err error) error {
+		if err != nil {
+			return fmt.Errorf("error accessing file %s: %w", filePath, err)
+		}
+
+		if !info.IsDir() {
+			files[filePath] = info
+		}
+
+		return nil
+	}); err != nil {
+		return fmt.Errorf("error walking the build context directory %s: %w", buildContextDir, err)
+	}
+
+	// Create the directory for the .tar.gz file if it doesn't exist.
+	if err := os.MkdirAll(path.Dir(tarGzPath), 0o750); err != nil {
+		return fmt.Errorf("can't create the archive destination directory %q: %w", path.Dir(tarGzPath), err)
+	}
+
+	// Create the .tar.gz file.
+	tarGzFile, err := os.Create(tarGzPath) //nolint:gosec
+	if err != nil {
+		return fmt.Errorf("can't create tar.gz file %s: %w", tarGzPath, err)
+	}
+	defer func() {
+		_ = tarGzFile.Close()
+	}()
+
+	gzipWriter := gzip.NewWriter(tarGzFile)
+	defer func() {
+		_ = gzipWriter.Close()
+	}()
+
+	tarWriter := tar.NewWriter(gzipWriter)
+	defer func() {
+		_ = tarWriter.Close()
+	}()
+
+	for filePath, info := range files {
+		if err := writeTarArchive(tarWriter, buildContextDir, filePath, info); err != nil {
+			return fmt.Errorf("writing tar archive %q: %w", filePath, err)
+		}
+	}
+
+	return nil
+}
+
+func writeTarArchive(writer *tar.Writer, basePath, path string, info fs.FileInfo) error {
+	if _, err := os.Stat(path); err != nil {
+		if os.IsNotExist(err) {
+			return fmt.Errorf("file %q does not exist: %w", path, err)
+		}
+	}
+	header, err := tar.FileInfoHeader(info, path)
+	if err != nil {
+		return fmt.Errorf("creating header for file %q: %w", path, err)
+	}
+
+	relPath, err := filepath.Rel(basePath, path)
+	if err != nil {
+		return fmt.Errorf("getting relative path for file %q: %w", path, err)
+	}
+	header.Name = relPath
+
+	if err := writer.WriteHeader(header); err != nil {
+		return fmt.Errorf("writing header for file %q: %w", header.Name, err)
+	}
+
+	file, err := os.Open(path)
+	if err != nil {
+		return fmt.Errorf("opening file %q: %w", path, err)
+	}
+
+	if _, err := io.Copy(writer, file); err != nil {
+		return fmt.Errorf("writing file %q to tar archive: %w", path, err)
+	}
+
+	if err := file.Close(); err != nil {
+		logger.Errorf("closing file %q: %s", path, err)
+	}
+
+	return nil
+}
+
+// uploadBuildContext uploads the file to the remote location.
+func uploadBuildContext(uploader FileUploader, tarGzPath string, targetPath string) error {
+	logger.Infof("Uploading build-context to S3")
+
+	defer func() {
+		if err := os.Remove(tarGzPath); err != nil {
+			logger.Errorf("can't remove file %s: %v", tarGzPath, err)
+		}
+	}()
+
+	err := uploader.UploadFile(tarGzPath, targetPath)
+	if err != nil {
+		return fmt.Errorf("can't upload context archive: %w", err)
+	}
+
+	return nil
+}

--- a/pkg/buildkit/context_remote_test.go
+++ b/pkg/buildkit/context_remote_test.go
@@ -1,0 +1,336 @@
+//nolint:testpackage
+package buildkit
+
+import (
+	"archive/tar"
+	"bytes"
+	"errors"
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/radiofrance/dib/pkg/types"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// Mock implementation for FileUploader.
+type mockUploader struct {
+	mockUploadResponseVal       error
+	mockPresignedURLResponseVal string
+	mockPresignedURLErrorVal    error
+}
+
+func newMockUploader() *mockUploader {
+	return &mockUploader{}
+}
+
+func (m *mockUploader) UploadFile(_ string, _ string) error {
+	return m.mockUploadResponseVal
+}
+
+func (m *mockUploader) PresignedURL(_ string) (string, error) {
+	return m.mockPresignedURLResponseVal, m.mockPresignedURLErrorVal
+}
+
+func (m *mockUploader) mockUploadResponse(err error) {
+	m.mockUploadResponseVal = err
+}
+
+func (m *mockUploader) mockPresignedURLResponse(url string, err error) {
+	m.mockPresignedURLResponseVal = url
+	m.mockPresignedURLErrorVal = err
+}
+
+func TestUploadBuildContext(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name          string
+		setup         func(mup *mockUploader)
+		tarGzPath     string
+		targetPath    string
+		expectedError bool
+	}{
+		{
+			name: "successful_upload",
+			setup: func(mup *mockUploader) {
+				mup.mockUploadResponse(nil)
+			},
+			tarGzPath:     "test.tar.gz",
+			targetPath:    "remote/test.tar.gz",
+			expectedError: false,
+		},
+		{
+			name: "upload_error",
+			setup: func(mup *mockUploader) {
+				mup.mockUploadResponse(fmt.Errorf("upload failed"))
+			},
+			tarGzPath:     "test.tar.gz",
+			targetPath:    "remote/test.tar.gz",
+			expectedError: true,
+		},
+		{
+			name: "file_deletion_error",
+			setup: func(mup *mockUploader) {
+				mup.mockUploadResponse(nil)
+			},
+			tarGzPath:     "missing.tar.gz",
+			targetPath:    "remote/missing.tar.gz",
+			expectedError: false,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			t.Parallel()
+			mockUploader := newMockUploader()
+			if test.setup != nil {
+				test.setup(mockUploader)
+			}
+			test.tarGzPath = filepath.Join(t.TempDir(), test.tarGzPath)
+			f, err := os.Create(test.tarGzPath)
+			if err == nil {
+				err = f.Close()
+				require.NoError(t, err)
+			}
+
+			err = uploadBuildContext(mockUploader, test.tarGzPath, test.targetPath)
+			assert.Equal(t, test.expectedError, err != nil)
+			if !test.expectedError {
+				_, err := os.Stat(test.tarGzPath)
+				assert.True(t, os.IsNotExist(err), "file should be removed after upload")
+			}
+		})
+	}
+}
+
+func TestPrepareContext(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name          string
+		imageOpts     types.ImageBuilderOpts
+		mockResponses func(mup *mockUploader)
+		expectedURL   string
+		expectedError bool
+	}{
+		{
+			name: "success_setup",
+			imageOpts: types.ImageBuilderOpts{
+				Context: "test_context_success",
+				Tags:    []string{"sample/image:tag"},
+			},
+			mockResponses: func(mup *mockUploader) {
+				mup.mockUploadResponse(nil)
+				mup.mockPresignedURLResponse("https://example.com/buildkit/sample/image/context.tar.gz", nil)
+			},
+			expectedURL:   "https://example.com/buildkit/sample/image/context.tar.gz",
+			expectedError: false,
+		},
+		{
+			name: "missing_context_dir",
+			imageOpts: types.ImageBuilderOpts{
+				Context: "invalid_context",
+				Tags:    []string{"sample/image:tag"},
+			},
+			mockResponses: nil,
+			expectedError: true,
+		},
+		{
+			name: "upload_fail",
+			imageOpts: types.ImageBuilderOpts{
+				Context: "test_context_upload_fail",
+				Tags:    []string{"sample/image:tag"},
+			},
+			mockResponses: func(mup *mockUploader) {
+				mup.mockUploadResponse(fmt.Errorf("upload failed"))
+			},
+			expectedError: true,
+		},
+		{
+			name: "presigned_url_fail",
+			imageOpts: types.ImageBuilderOpts{
+				Context: "test_context_presigned_url_fail",
+				Tags:    []string{"sample/image:tag"},
+			},
+			mockResponses: func(mup *mockUploader) {
+				mup.mockUploadResponse(nil)
+				mup.mockPresignedURLResponse("", fmt.Errorf("failed to get presigned url"))
+			},
+			expectedError: true,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			t.Parallel()
+
+			mockUploader := newMockUploader()
+			provider := NewRemoteContextProvider(mockUploader)
+
+			if test.mockResponses != nil {
+				test.mockResponses(mockUploader)
+			}
+			if test.imageOpts.Context != "invalid_context" {
+				test.imageOpts.Context = filepath.Join(t.TempDir(), test.imageOpts.Context)
+				err := os.Mkdir(test.imageOpts.Context, 0o750)
+				require.NoError(t, err)
+				defer func() {
+					err = os.RemoveAll(test.imageOpts.Context)
+					require.NoError(t, err)
+				}()
+			}
+
+			url, err := provider.PrepareContext(test.imageOpts)
+
+			assert.Equal(t, test.expectedError, err != nil)
+			if !test.expectedError {
+				assert.Equal(t, test.expectedURL, url)
+			}
+		})
+	}
+}
+
+func TestWriteTarArchive(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name          string
+		files         map[string]string
+		expectedFiles map[string]string
+		expectedError bool
+	}{
+		{
+			name: "success_single_file",
+			files: map[string]string{
+				"file1.txt": "content1",
+			},
+			expectedFiles: map[string]string{
+				"file1.txt": "content1",
+			},
+			expectedError: false,
+		},
+		{
+			name: "success_multiple_files",
+			files: map[string]string{
+				"file1.txt": "content1",
+				"file2.txt": "content2",
+			},
+			expectedFiles: map[string]string{
+				"file1.txt": "content1",
+				"file2.txt": "content2",
+			},
+			expectedError: false,
+		},
+		{
+			name:          "empty_directory",
+			files:         nil,
+			expectedFiles: map[string]string{},
+			expectedError: false,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			t.Parallel()
+
+			// Create a temporary directory for the test
+			tempDir := t.TempDir()
+
+			// Create test files if specified
+			for fileName, content := range test.files {
+				filePath := filepath.Join(tempDir, fileName)
+				err := os.MkdirAll(filepath.Dir(filePath), 0o750)
+				require.NoError(t, err, "failed to create directory structure")
+				err = os.WriteFile(filePath, []byte(content), 0o644)
+				require.NoError(t, err, "unable to create file", filePath)
+			}
+
+			// Create a buffer to store the tar archive
+			var buffer io.ReadWriter = new(bytes.Buffer)
+			tarWriter := tar.NewWriter(buffer)
+			defer func() {
+				err := tarWriter.Close()
+				require.NoError(t, err)
+			}()
+
+			// Test writing files to a tar archive
+			for fileName := range test.files {
+				filePath := filepath.Join(tempDir, fileName)
+				fileInfo, err := os.Stat(filePath)
+				if os.IsNotExist(err) {
+					assert.True(t, test.expectedError, "expected an error but didn't get one")
+					return
+				} else if err != nil {
+					t.Fatalf("unexpected error: %v", err)
+				}
+				err = writeTarArchive(tarWriter, tempDir, filePath, fileInfo)
+				assert.Equal(t, test.expectedError, err != nil)
+			}
+
+			// Verify archive content if no error was expected
+			if !test.expectedError {
+				tarReader := tar.NewReader(buffer)
+				extractedFiles := map[string]string{}
+				for {
+					header, err := tarReader.Next()
+					if errors.Is(err, io.EOF) {
+						break
+					}
+					require.NoError(t, err, "failed to read tar archive")
+					content, err := io.ReadAll(tarReader)
+					require.NoError(t, err, "failed to read file content from tar archive")
+					extractedFiles[header.Name] = string(content)
+				}
+				assert.Equal(t, test.expectedFiles, extractedFiles)
+			}
+		})
+	}
+}
+
+func TestCreateArchive(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name          string
+		files         map[string]string
+		expectedError bool
+	}{
+		{
+			name: "success",
+			files: map[string]string{
+				"file1.txt": "content1",
+				"file2.txt": "content2",
+			},
+			expectedError: false,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			t.Parallel()
+			tempDir := t.TempDir()
+			if test.files != nil {
+				for fileName, content := range test.files {
+					filePath := filepath.Join(tempDir, fileName)
+					if err := os.WriteFile(filePath, []byte(content), 0o644); err != nil {
+						t.Fatalf("unable to create test file: %v", err)
+					}
+				}
+			}
+
+			archiveFilePath := filepath.Join(tempDir, "test.tar.gz")
+			err := createArchive(tempDir, archiveFilePath)
+			assert.Equal(t, test.expectedError, err != nil)
+
+			if !test.expectedError {
+				_, err := os.Stat(archiveFilePath)
+				assert.NoError(t, err, "expected archive file to exist")
+			}
+		})
+	}
+}

--- a/pkg/buildkit/s3.go
+++ b/pkg/buildkit/s3.go
@@ -1,0 +1,85 @@
+package buildkit
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"net/http"
+	"os"
+	"time"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/service/s3"
+	"github.com/aws/aws-sdk-go-v2/service/s3/types"
+	"github.com/radiofrance/dib/internal/logger"
+)
+
+// S3Uploader is a FileUploader that uploads files to an AWS S3 bucket.
+type S3Uploader struct {
+	s3     *s3.Client
+	bucket string
+}
+
+// NewS3Uploader creates a new instance of S3Uploader.
+func NewS3Uploader(cfg aws.Config, bucket string) *S3Uploader {
+	return &S3Uploader{
+		s3:     s3.NewFromConfig(cfg),
+		bucket: bucket,
+	}
+}
+
+// UploadFile uploads a file to an AWS S3 bucket.
+func (u S3Uploader) UploadFile(filePath string, targetPath string) error {
+	file, err := os.Open(filePath) //nolint:gosec
+	if err != nil {
+		return fmt.Errorf("can't open file %s: %w", filePath, err)
+	}
+
+	defer func() {
+		if err := file.Close(); err != nil {
+			logger.Errorf("can't close file %s: %v", filePath, err)
+		}
+	}()
+
+	// Get file size and read the file content into a buffer
+	fileInfo, _ := file.Stat()
+	size := fileInfo.Size()
+	buffer := make([]byte, size)
+	_, err = file.Read(buffer)
+	if err != nil {
+		return fmt.Errorf("can't read file %s: %w", filePath, err)
+	}
+
+	query := &s3.PutObjectInput{
+		Bucket:        aws.String(u.bucket),
+		Key:           aws.String(targetPath),
+		ACL:           types.ObjectCannedACLPrivate,
+		Body:          bytes.NewReader(buffer),
+		ContentLength: &size,
+		ContentType:   aws.String(http.DetectContentType(buffer)),
+	}
+
+	_, err = u.s3.PutObject(context.Background(), query)
+	if err != nil {
+		return fmt.Errorf("can't send S3 PUT request: %w", err)
+	}
+
+	return nil
+}
+
+// PresignedURL generates a presigned URL for accessing an object in the S3 bucket.
+// The URL is valid for a limited time and allows temporary access to the specified object.
+func (u S3Uploader) PresignedURL(targetPath string) (string, error) {
+	presignClient := s3.NewPresignClient(u.s3)
+	presignParams := &s3.GetObjectInput{
+		Bucket: aws.String(u.bucket),
+		Key:    aws.String(targetPath),
+	}
+	presignedURL, err := presignClient.PresignGetObject(context.Background(), presignParams, func(o *s3.PresignOptions) {
+		o.Expires = 1 * time.Hour
+	})
+	if err != nil {
+		return "", fmt.Errorf("can't generate presigned URL: %w", err)
+	}
+	return presignedURL.URL, nil
+}

--- a/pkg/dib/metadata.go
+++ b/pkg/dib/metadata.go
@@ -8,7 +8,7 @@ import (
 	"time"
 
 	"github.com/radiofrance/dib/pkg/dag"
-	"github.com/radiofrance/dib/pkg/exec"
+	"github.com/radiofrance/dib/pkg/executor"
 )
 
 // ImageMetadata contains information about an image and allows to convert it to standard OCI image labels.
@@ -35,7 +35,7 @@ type ImageMetadata struct {
 // LoadCommonMetadata returns a ImageMetadata struct filled with metadata from the current build environment.
 // It automatically discovers environment variables from different CI vendors (GitHub actions, GitLab CI),
 // or fallback to using local git repository as metadata source.
-func LoadCommonMetadata(cmd exec.Executor) ImageMetadata {
+func LoadCommonMetadata(cmd executor.ShellExecutor) ImageMetadata {
 	meta := ImageMetadata{}
 
 	metadataLoaded := false
@@ -131,7 +131,7 @@ func loadGitLabMeta(meta *ImageMetadata) {
 	meta.repositoryTag = os.Getenv("CI_COMMIT_TAG")
 }
 
-func loadGitMeta(meta *ImageMetadata, cmd exec.Executor) {
+func loadGitMeta(meta *ImageMetadata, cmd executor.ShellExecutor) {
 	if rev, err := cmd.Execute("git", "rev-parse", "HEAD"); err == nil {
 		meta.Revision = strings.Trim(rev, "\n")
 	}

--- a/pkg/dib/metadata_test.go
+++ b/pkg/dib/metadata_test.go
@@ -42,7 +42,7 @@ func Test_LabelsFromGitHubMetadata(t *testing.T) {
 	}
 
 	// When
-	meta := dib.LoadCommonMetadata(&mock.Executor{}).WithImage(image)
+	meta := dib.LoadCommonMetadata(&mock.ShellExecutor{}).WithImage(image)
 	meta.Created = now
 	actual := meta.ToLabels()
 
@@ -86,7 +86,7 @@ func Test_LabelsFromGitLabMetadata(t *testing.T) {
 	}
 
 	// When
-	meta := dib.LoadCommonMetadata(&mock.Executor{}).WithImage(image)
+	meta := dib.LoadCommonMetadata(&mock.ShellExecutor{}).WithImage(image)
 	meta.Created = now
 	actual := meta.ToLabels()
 
@@ -126,7 +126,7 @@ func Test_LabelsFromGitMetadata(t *testing.T) {
 		},
 	}
 
-	cmd := mock.NewExecutor([]mock.ExecutorResult{
+	cmd := mock.NewShellExecutor([]mock.ExecutorResult{
 		{
 			// git rev-parse HEAD
 			Output: "e6d0536487b24c11ca8675cbf8e1b015f843bd26\n",

--- a/pkg/docker/builder.go
+++ b/pkg/docker/builder.go
@@ -4,19 +4,20 @@ import (
 	"fmt"
 	"strings"
 
+	"github.com/radiofrance/dib/pkg/executor"
+
 	"github.com/radiofrance/dib/internal/logger"
-	"github.com/radiofrance/dib/pkg/exec"
 	"github.com/radiofrance/dib/pkg/types"
 )
 
 // ImageBuilderTagger builds an image using the docker command-line executable.
 type ImageBuilderTagger struct {
-	exec   exec.Executor
+	exec   executor.ShellExecutor
 	dryRun bool
 }
 
 // NewImageBuilderTagger creates a new instance of an ImageBuilderTagger.
-func NewImageBuilderTagger(executor exec.Executor, dryRun bool) *ImageBuilderTagger {
+func NewImageBuilderTagger(executor executor.ShellExecutor, dryRun bool) *ImageBuilderTagger {
 	return &ImageBuilderTagger{executor, dryRun}
 }
 

--- a/pkg/docker/builder_test.go
+++ b/pkg/docker/builder_test.go
@@ -41,7 +41,7 @@ func provideDefaultOptions() types.ImageBuilderOpts {
 func Test_Build_DryRun(t *testing.T) {
 	t.Parallel()
 
-	fakeExecutor := mock.NewExecutor(nil)
+	fakeExecutor := mock.NewShellExecutor(nil)
 	builder := docker.NewImageBuilderTagger(fakeExecutor, true)
 
 	opts := provideDefaultOptions()
@@ -54,7 +54,7 @@ func Test_Build_DryRun(t *testing.T) {
 func Test_Build_Executes(t *testing.T) {
 	t.Parallel()
 
-	fakeExecutor := mock.NewExecutor(nil)
+	fakeExecutor := mock.NewShellExecutor(nil)
 	builder := docker.NewImageBuilderTagger(fakeExecutor, false)
 
 	opts := provideDefaultOptions()
@@ -96,7 +96,7 @@ func Test_Build_Executes(t *testing.T) {
 func Test_Build_ExecutesDisablesPush(t *testing.T) {
 	t.Parallel()
 
-	fakeExecutor := mock.NewExecutor(nil)
+	fakeExecutor := mock.NewShellExecutor(nil)
 	builder := docker.NewImageBuilderTagger(fakeExecutor, false)
 
 	opts := provideDefaultOptions()
@@ -124,7 +124,7 @@ func Test_Build_ExecutesDisablesPush(t *testing.T) {
 func Test_Build_FailsOnExecutorError(t *testing.T) {
 	t.Parallel()
 
-	fakeExecutor := mock.NewExecutor([]mock.ExecutorResult{
+	fakeExecutor := mock.NewShellExecutor([]mock.ExecutorResult{
 		{
 			Output: "",
 			Error:  errors.New("something wrong happened"),
@@ -140,7 +140,7 @@ func Test_Build_FailsOnExecutorError(t *testing.T) {
 func Test_Tag(t *testing.T) {
 	t.Parallel()
 
-	fakeExecutor := mock.NewExecutor(nil)
+	fakeExecutor := mock.NewShellExecutor(nil)
 	tagger := docker.NewImageBuilderTagger(fakeExecutor, false)
 
 	err := tagger.Tag("registry/image:src-tag", "registry/image:dest-tag")
@@ -161,7 +161,7 @@ func Test_Tag(t *testing.T) {
 func Test_Tag_DryRun(t *testing.T) {
 	t.Parallel()
 
-	fakeExecutor := mock.NewExecutor(nil)
+	fakeExecutor := mock.NewShellExecutor(nil)
 	tagger := docker.NewImageBuilderTagger(fakeExecutor, true)
 
 	err := tagger.Tag("registry/image:src-tag", "registry/image:dest-tag")

--- a/pkg/exec/kubernetes.go
+++ b/pkg/exec/kubernetes.go
@@ -1,0 +1,71 @@
+package exec
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"io"
+
+	"github.com/radiofrance/dib/internal/logger"
+	k8sutils "github.com/radiofrance/dib/pkg/kubernetes"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/client-go/kubernetes"
+)
+
+// KubernetesExecutor will run Buildkit in a Kubernetes cluster.
+type KubernetesExecutor struct {
+	clientSet kubernetes.Interface
+}
+
+// NewKubernetesExecutor creates a new instance of KubernetesExecutor.
+func NewKubernetesExecutor(clientSet kubernetes.Interface) *KubernetesExecutor {
+	return &KubernetesExecutor{
+		clientSet: clientSet,
+	}
+}
+
+// ApplyWithWriters executes a Buildkit build using a Kubernetes Pod.
+// Currently, this function is designed to handle only Pod objects.
+// It may evolve in the future to support other types of Kubernetes objects.
+//
+//nolint:lll
+func (e KubernetesExecutor) ApplyWithWriters(ctx context.Context, stdout, stderr io.Writer, k8sObject runtime.Object, containerNames string) error {
+	pod, ok := k8sObject.(*corev1.Pod)
+	if !ok {
+		return errors.New("only pod object is supported")
+	}
+
+	watcher, err := e.clientSet.CoreV1().Pods(pod.Namespace).Watch(ctx, metav1.ListOptions{
+		LabelSelector: fmt.Sprintf("app.kubernetes.io/instance=%s", pod.Name),
+		Watch:         true,
+	})
+	if err != nil {
+		return fmt.Errorf("failed to watch pod: %w", err)
+	}
+	defer watcher.Stop()
+
+	readyChan, errChan := k8sutils.MonitorPod(ctx, watcher)
+	go func() {
+		<-readyChan
+		k8sutils.PrintPodLogs(ctx, io.MultiWriter(stdout, stderr), e.clientSet, pod.Namespace, pod.Name, containerNames)
+	}()
+
+	_, err = e.clientSet.CoreV1().Pods(pod.Namespace).Create(ctx, pod, metav1.CreateOptions{})
+	if err != nil {
+		return fmt.Errorf("failed to create Buildkit pod: %w", err)
+	}
+	defer func() {
+		err := e.clientSet.CoreV1().Pods(pod.Namespace).Delete(ctx, pod.Name, metav1.DeleteOptions{})
+		if err != nil {
+			logger.Warnf("Failed to delete Buildkit pod %s, ignoring: %v", pod.Name, err)
+		}
+	}()
+
+	err = <-errChan
+	if err != nil {
+		return fmt.Errorf("error watching Buildkit pod: %w", err)
+	}
+	return nil
+}

--- a/pkg/exec/shell.go
+++ b/pkg/exec/shell.go
@@ -10,22 +10,18 @@ import (
 	"github.com/radiofrance/dib/internal/logger"
 )
 
-// Executor is an interface for dealing with command execution.
-type Executor interface {
-	// Execute a command and return the standard output.
-	Execute(name string, args ...string) (string, error)
-	// ExecuteStdout executes a command and prints the standard output instead of returning it.
-	ExecuteStdout(name string, args ...string) error
-	// ExecuteWithWriter executes a command and forwards both stdout and stderr to a single io.Writer
-	ExecuteWithWriter(writer io.Writer, name string, args ...string) error
-	// ExecuteWithWriters executes a command and forwards stdout and stderr to an io.Writer
-	ExecuteWithWriters(stdout, stderr io.Writer, name string, args ...string) error
-}
-
 // ShellExecutor is an implementation of Executor that uses the standard exec package to run shell commands.
 type ShellExecutor struct {
 	Dir string
 	Env []string
+}
+
+// NewShellExecutor initializes a ShellExecutor with the specified working directory and environment variables.
+func NewShellExecutor(workingDir string, env []string) *ShellExecutor {
+	return &ShellExecutor{
+		Dir: workingDir,
+		Env: env,
+	}
 }
 
 // Execute a shell command and return the standard output.

--- a/pkg/executor/executor.go
+++ b/pkg/executor/executor.go
@@ -1,0 +1,31 @@
+package executor
+
+import (
+	"context"
+	"io"
+
+	"k8s.io/apimachinery/pkg/runtime"
+)
+
+/*
+Package executor defines interfaces for execution functionalities (producer)
+that can be utilized by various builders, such as Kubernetes-based or shell-based executors.
+*/
+
+// K8sExecutor defines an interface for executing Kubernetes-based Buildkit builds.
+type KubernetesExecutor interface {
+	// ApplyWithWriters executes a Kubernetes Pod and streams its logs to the provided stdout and stderr writers.
+	ApplyWithWriters(ctx context.Context, stdout, stderr io.Writer, k8sObject runtime.Object, containerNames string) error
+}
+
+// ShellExecutor defines an interface for executing shell commands with various output handling options.
+type ShellExecutor interface {
+	// Execute a command and return the standard output.
+	Execute(name string, args ...string) (string, error)
+	// ExecuteStdout executes a command and prints the standard output instead of returning it.
+	ExecuteStdout(name string, args ...string) error
+	// ExecuteWithWriter executes a command and forwards both stdout and stderr to a single io.Writer
+	ExecuteWithWriter(writer io.Writer, name string, args ...string) error
+	// ExecuteWithWriters executes a command and forwards stdout and stderr to an io.Writer
+	ExecuteWithWriters(stdout, stderr io.Writer, name string, args ...string) error
+}

--- a/pkg/goss/executor_kubernetes.go
+++ b/pkg/goss/executor_kubernetes.go
@@ -136,7 +136,7 @@ func (e KubernetesExecutor) Execute(ctx context.Context, output io.Writer, opts 
 	}
 	defer watcher.Stop()
 
-	readyChan, watchErrChan := k8sutils.WaitPodReady(ctx, watcher)
+	readyChan, watchErrChan := k8sutils.MonitorPod(ctx, watcher)
 
 	errChan := make(chan error)
 	go func() {

--- a/pkg/kaniko/builder.go
+++ b/pkg/kaniko/builder.go
@@ -6,9 +6,10 @@ import (
 	"io"
 	"strings"
 
+	"github.com/radiofrance/dib/pkg/executor"
+
 	"github.com/aws/aws-sdk-go-v2/config"
 	"github.com/radiofrance/dib/internal/logger"
-	"github.com/radiofrance/dib/pkg/exec"
 	"github.com/radiofrance/dib/pkg/kubernetes"
 	"github.com/radiofrance/dib/pkg/types"
 	"github.com/radiofrance/kubecli"
@@ -106,7 +107,7 @@ func (b Builder) Build(opts types.ImageBuilderOpts) error {
 	return b.executor.Execute(context.Background(), opts.LogOutput, kanikoArgs)
 }
 
-func CreateBuilder(cfg Config, shell exec.Executor, workingDir string, localOnly, dryRun bool) *Builder {
+func CreateBuilder(cfg Config, shell executor.ShellExecutor, workingDir string, localOnly, dryRun bool) *Builder {
 	var (
 		err             error
 		executor        Executor
@@ -136,7 +137,7 @@ func CreateBuilder(cfg Config, shell exec.Executor, workingDir string, localOnly
 	return kanikoBuilder
 }
 
-func createKanikoDockerExecutor(shell exec.Executor, contextRootDir string, cfg Config) *DockerExecutor {
+func createKanikoDockerExecutor(shell executor.ShellExecutor, contextRootDir string, cfg Config) *DockerExecutor {
 	dockerCfg := ContainerConfig{
 		Image: cfg.Executor.Docker.Image,
 		Env:   map[string]string{},

--- a/pkg/kaniko/executor_docker.go
+++ b/pkg/kaniko/executor_docker.go
@@ -6,8 +6,9 @@ import (
 	"io"
 	"os"
 
+	"github.com/radiofrance/dib/pkg/executor"
+
 	"github.com/radiofrance/dib/internal/logger"
-	"github.com/radiofrance/dib/pkg/exec"
 )
 
 // ContainerConfig holds the configuration options for the docker container.
@@ -19,13 +20,13 @@ type ContainerConfig struct {
 
 // DockerExecutor will run Kaniko in a docker container.
 type DockerExecutor struct {
-	exec         exec.Executor
+	exec         executor.ShellExecutor
 	config       ContainerConfig
 	DockerConfig string // Path to the docker config directory to mount in the Kaniko container.
 }
 
 // NewDockerExecutor creates a new instance of DockerExecutor.
-func NewDockerExecutor(exec exec.Executor, config ContainerConfig) *DockerExecutor {
+func NewDockerExecutor(exec executor.ShellExecutor, config ContainerConfig) *DockerExecutor {
 	dockerCfg := os.Getenv("DOCKER_CONFIG")
 	if dockerCfg == "" {
 		dockerCfg = fmt.Sprintf("%s/.docker", os.Getenv("HOME"))

--- a/pkg/kaniko/executor_docker_test.go
+++ b/pkg/kaniko/executor_docker_test.go
@@ -12,7 +12,7 @@ import (
 func Test_DockerExecutor_Execute(t *testing.T) {
 	t.Setenv("HOME", "/home/dib")
 
-	shell := mock.NewExecutor([]mock.ExecutorResult{
+	shell := mock.NewShellExecutor([]mock.ExecutorResult{
 		{
 			Output: "some output",
 			Error:  nil,

--- a/pkg/kaniko/executor_kubernetes.go
+++ b/pkg/kaniko/executor_kubernetes.go
@@ -174,7 +174,7 @@ func (e KubernetesExecutor) Execute(ctx context.Context, output io.Writer, args 
 	}
 	defer watcher.Stop()
 
-	readyChan, errChan := k8sutils.WaitPodReady(ctx, watcher)
+	readyChan, errChan := k8sutils.MonitorPod(ctx, watcher)
 	go func() {
 		<-readyChan
 		k8sutils.PrintPodLogs(ctx, output, e.clientSet, e.PodConfig.Namespace, podName, containerName)

--- a/pkg/kubernetes/pod.go
+++ b/pkg/kubernetes/pod.go
@@ -16,13 +16,13 @@ import (
 	"k8s.io/client-go/kubernetes"
 )
 
-// WaitPodReady waits for a pod to be in running state.
+// MonitorPod waits for a pod to be in running state.
 // The function is non-blocking, it returns 2 channels that will be used as event dispatchers:
 // - When the pod reaches the running state, an empty struct is sent to readyChan.
 // - When the pod reached completion, nil is sent to errChan on success, or an error if the pod failed.
 // - If the 1-hour timeout is reached, an error is sent to errChan.
 // - If the passed context is cancelled or timeouts, an error is sent to errChan.
-func WaitPodReady(ctx context.Context, watcher watch.Interface) (chan struct{}, chan error) {
+func MonitorPod(ctx context.Context, watcher watch.Interface) (chan struct{}, chan error) {
 	readyChan := make(chan struct{})
 	errChan := make(chan error)
 	running := false

--- a/pkg/trivy/executor_kubernetes.go
+++ b/pkg/trivy/executor_kubernetes.go
@@ -135,7 +135,7 @@ func (e KubernetesExecutor) Execute(ctx context.Context, output io.Writer, args 
 	}
 	defer watcher.Stop()
 
-	readyChan, errChan := k8sutils.WaitPodReady(ctx, watcher)
+	readyChan, errChan := k8sutils.MonitorPod(ctx, watcher)
 	go func() {
 		<-readyChan
 		k8sutils.PrintPodLogs(ctx, output, e.clientSet, e.PodConfig.Namespace, podName, containerName)

--- a/pkg/types/types.go
+++ b/pkg/types/types.go
@@ -30,6 +30,8 @@ type ImageBuilderOpts struct {
 	Context string
 	// File is the name of the Dockerfile
 	File string
+	//  LocalOnly is true if the build context is local and not remote.
+	LocalOnly bool
 	// Target is the target of the build
 	Target string
 	// Name of the tags to build, same as passed to the '-t' flag of the docker build command.


### PR DESCRIPTION
This pull request introduces significant enhancements to the BuildKit backend by adding support for remote build contexts, as well as Kubernetes-based execution.

### Build Context Enhancements:
* Introduced `LocalContextProvider` and `RemoteContextProvider` to manage local and remote build contexts, respectively. Remote contexts are uploaded to storage (e.g., S3) and accessed via `pre-signed URLs` with 1 hour duration. 

### Kubernetes Integration:
* Added a Kubernetes executor (`bkKubernetesExecutor`) to run BuildKit builds in Kubernetes pods, including pod configuration, Docker config secrets, and environment variables. (`pkg/buildkit/builder.go`)
* Implemented the `buildPod` function to dynamically create Kubernetes pods for BuildKit builds, with support for custom configurations and security contexts. (`pkg/buildkit/builder.go`)

### Build Command Updates:
* Modified the `processBuildCommandFlag` and `doBuild` functions to handle the `LocalOnly` flag and select the appropriate context provider and executor. (`cmd/build.go`)
* [x] Introduce a `Push` flag to explicitly control the push behavior, and decouple `Push` from `p.LocalOnly`, as pushing can be applicable for both local and remote builds.

### Utility Additions:
* Added `GetRemoteBuildkitHostAddress` to compute the remote BuildKit host address dynamically based on user ID. (`pkg/buildkit/buildkitutil.go`)
* Introduced helper functions for creating and uploading tarball archives of build contexts for remote builds. (`pkg/buildkit/context_remote.go`)