### PR TITLE
Add cross-platform rootless detection in builder test

### DIFF
--- a/pkg/buildkit/builder_darwin_test.go
+++ b/pkg/buildkit/builder_darwin_test.go
@@ -1,4 +1,0 @@
-//nolint:testpackage
-package buildkit
-
-const runtimeVariableDataDir = "/var/run"

--- a/pkg/buildkit/builder_linux_test.go
+++ b/pkg/buildkit/builder_linux_test.go
@@ -1,4 +1,0 @@
-//nolint:testpackage
-package buildkit
-
-const runtimeVariableDataDir = "/run"

--- a/pkg/buildkit/builder_test.go
+++ b/pkg/buildkit/builder_test.go
@@ -61,7 +61,7 @@ func Test_Build(t *testing.T) {
 			modifyOpts: func(opts *types.ImageBuilderOpts) {},
 			expectedBuildArgsFunc: func(context string) []string {
 				return []string{
-					fmt.Sprintf("--addr=%s", fmt.Sprintf("unix://%s/buildkit/buildkitd.sock", runtimeVariableDataDir)),
+					fmt.Sprintf("--addr=%s", getBuildkitHostAddress()),
 					"build",
 					"--progress=auto",
 					"--frontend=dockerfile.v0",
@@ -82,7 +82,7 @@ func Test_Build(t *testing.T) {
 			},
 			expectedBuildArgsFunc: func(context string) []string {
 				return []string{
-					fmt.Sprintf("--addr=%s", fmt.Sprintf("unix://%s/buildkit/buildkitd.sock", runtimeVariableDataDir)),
+					fmt.Sprintf("--addr=%s", getBuildkitHostAddress()),
 					"build",
 					"--progress=auto",
 					"--frontend=dockerfile.v0",
@@ -103,7 +103,7 @@ func Test_Build(t *testing.T) {
 			},
 			expectedBuildArgsFunc: func(context string) []string {
 				return []string{
-					fmt.Sprintf("--addr=%s", fmt.Sprintf("unix://%s/buildkit/buildkitd.sock", runtimeVariableDataDir)),
+					fmt.Sprintf("--addr=%s", getBuildkitHostAddress()),
 					"build",
 					"--progress=auto",
 					"--frontend=dockerfile.v0",
@@ -124,7 +124,7 @@ func Test_Build(t *testing.T) {
 			},
 			expectedBuildArgsFunc: func(context string) []string {
 				return []string{
-					fmt.Sprintf("--addr=%s", fmt.Sprintf("unix://%s/buildkit/buildkitd.sock", runtimeVariableDataDir)),
+					fmt.Sprintf("--addr=%s", getBuildkitHostAddress()),
 					"build",
 					"--progress=auto",
 					"--frontend=dockerfile.v0",
@@ -145,7 +145,7 @@ func Test_Build(t *testing.T) {
 			},
 			expectedBuildArgsFunc: func(context string) []string {
 				return []string{
-					fmt.Sprintf("--addr=%s", fmt.Sprintf("unix://%s/buildkit/buildkitd.sock", runtimeVariableDataDir)),
+					fmt.Sprintf("--addr=%s", getBuildkitHostAddress()),
 					"build",
 					"--progress=auto",
 					"--frontend=dockerfile.v0",

--- a/pkg/buildkit/buildkitutil.go
+++ b/pkg/buildkit/buildkitutil.go
@@ -5,9 +5,9 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
-	
-	"github.com/radiofrance/dib/pkg/rootlessutil"
+
 	"github.com/radiofrance/dib/internal/logger"
+	"github.com/radiofrance/dib/pkg/rootlessutil"
 )
 
 const (

--- a/pkg/rootlessutil/rootless_linux.go
+++ b/pkg/rootlessutil/rootless_linux.go
@@ -5,10 +5,6 @@ import (
 	"os"
 )
 
-func IsRootless() bool {
-	return os.Geteuid() != 0
-}
-
 // https://specifications.freedesktop.org/basedir-spec/latest/
 func XDGRuntimeDir() string {
 	// XDG_RUNTIME_DIR is an environment variable specifying a user-specific directory for runtime files (e.g socket..)

--- a/pkg/rootlessutil/rootless_unix.go
+++ b/pkg/rootlessutil/rootless_unix.go
@@ -1,0 +1,9 @@
+package rootlessutil
+
+import (
+	"os"
+)
+
+func IsRootless() bool {
+	return os.Geteuid() != 0
+}


### PR DESCRIPTION
Replaced hardcoded `unixSocketPath`  with `getBuildkitHostAddress()` in tests for greater flexibility and maintainability. Removed `runtimeVariableDataDir` and related logic as it is no longer necessary. This simplifies the code and improves readability.