### PR TITLE
Add buildctl script and Dockerfile for buildkit integration && documentation

### DIFF
--- a/examples/Dockerfile
+++ b/examples/Dockerfile
@@ -1,0 +1,5 @@
+FROM moby/buildkit:master-rootless
+
+COPY buildkitd-launcher /usr/local/bin/buildkitd-launcher
+
+ENTRYPOINT ["buildkitd-launcher"]

--- a/examples/README.md
+++ b/examples/README.md
@@ -1,0 +1,133 @@
+# DIB (Docker Image Builder) Example Configuration Guide
+
+This guide explains how to configure and use the DIB example for building and pushing Docker images using Kubernetes.
+
+## Overview
+
+The example in this directory demonstrates how to use DIB to build Docker images using Buildkit in a Kubernetes cluster. The example includes:
+
+- A Dockerfile for creating a custom Buildkit image
+- A buildkitd-launcher script for starting the Buildkit daemon
+- A .dib.yaml configuration file for configuring the build process
+
+## Building and Pushing the Image
+
+The first step is to build and push the custom Buildkit image defined in the Dockerfile:
+
+```bash
+# Navigate to the examples directory
+cd examples
+
+# Build the image
+docker build -t <your-registry>/custome-buildkit:latest .
+
+# Push the image to your registry
+docker push <your-registry>/custome-buildkit:latest
+```
+
+Replace `<your-registry>` with your Docker registry URL. For example, using the registry from the .dib.yaml file:
+
+```bash
+docker build -t <your-registry>/custome-buildkit:latest .
+docker push <your-registry>/custome-buildkit:latest
+```
+
+## Creating Docker Config Secret
+
+DIB requires a Kubernetes secret containing Docker registry credentials to authenticate when pushing images. This secret is referenced by the `docker_config_secret` field in the .dib.yaml file.
+
+To create this secret:
+
+1. First, make sure you're logged in to your Docker registry:
+
+```bash
+docker login <your-registry>
+```
+
+2. Create a Kubernetes secret from your Docker config file:
+
+```bash
+kubectl create secret generic docker-config-prod \
+  --from-file=config.json=$HOME/.docker/config.json \
+  --namespace=default
+```
+
+This creates a secret named `docker-config-prod` in the `default` namespace, which matches the configuration in the .dib.yaml file.
+
+## Creating Image Pull Secrets
+
+Image pull secrets are used by Kubernetes to pull images from private registries. These secrets are referenced by the `image_pull_secrets` field in the .dib.yaml file.
+
+To create an image pull secret:
+
+```bash
+kubectl create secret docker-registry image-pull-secret \
+  --docker-server=<your-registry> \
+  --docker-username=<your-username> \
+  --docker-password=<your-password> \
+  --docker-email=<your-email> \
+  --namespace=default
+```
+
+Replace the placeholders with your registry information. For example:
+
+```bash
+kubectl create secret docker-registry image-pull-secret \
+  --docker-server=europe-west9-docker.pkg.dev \
+  --docker-username=_json_key \
+  --docker-password="$(cat /path/to/your/service-account-key.json)" \
+  --docker-email=your-email@example.com \
+  --namespace=default
+```
+
+For Google Container Registry (GCR) or Artifact Registry, you typically use a service account key as the password.
+
+## Configuring .dib.yaml
+
+The .dib.yaml file in this directory contains the configuration for DIB. Key fields include:
+
+- `registry_url`: The URL of your Docker registry
+- `buildkit.context.s3`: Configuration for storing the build context in an S3 bucket
+- `buildkit.executor.kubernetes`: Configuration for the Kubernetes executor
+  - `namespace`: The Kubernetes namespace to use
+  - `image`: The custom Buildkit image to use
+  - `docker_config_secret`: The name of the Docker config secret
+  - `image_pull_secrets`: The names of the image pull secrets
+
+Modify these fields as needed for your environment.
+
+## Additional Configuration
+
+### AWS S3 Bucket for Build Context
+
+If you're using an AWS S3 bucket for the build context (as configured in the .dib.yaml file), make sure:
+
+1. The S3 bucket exists and is accessible
+2. Your Kubernetes cluster has the necessary permissions to access the bucket
+3. You've configured the AWS region correctly
+
+### Kubernetes Namespace
+
+Ensure the namespace specified in the .dib.yaml file exists in your Kubernetes cluster:
+
+```bash
+kubectl create namespace <namespace>
+```
+
+### Resource Limits
+
+You can uncomment and modify the `container_override` section in the .dib.yaml file to set resource limits for the Buildkit container.
+
+## Running the Example
+
+Once everything is configured, you can use DIB to build and push Docker images:
+
+```bash
+dib build --backend buildkit --push
+```
+
+## Troubleshooting
+
+- If you encounter authentication issues, check that your Docker config secret is correctly created and referenced in the .dib.yaml file
+- If pods fail to start, check that the image pull secrets are correctly created and referenced
+- Check the pod logs for more detailed error messages: `kubectl logs <pod-name> -n <namespace>`

--- a/examples/buildkitd-launcher
+++ b/examples/buildkitd-launcher
@@ -1,0 +1,57 @@
+#!/usr/bin/env sh
+# this script spawns buildkitd instance for executing buildctl.
+#
+# Inspired from https://github.com/moby/buildkit/blob/master/examples/buildctl-daemonless/buildctl-daemonless.sh
+#
+# Usage: buildctl build ...
+#
+# Flags for buildkitd can be specified as $BUILDKITD_FLAGS .
+set -eu
+
+: ${BUILDCTL=buildctl}
+: ${BUILDCTL_CONNECT_RETRIES_MAX=10}
+: ${BUILDKITD=buildkitd}
+: ${BUILDKITD_FLAGS=}
+: ${ROOTLESSKIT=rootlesskit}
+
+# $tmp holds the following files:
+# * pid
+# * addr
+# * log
+tmp=$(mktemp -d /tmp/buildctl.XXXXXX)
+trap "kill \$(cat $tmp/pid) || true; wait \$(cat $tmp/pid) || true; rm -rf $tmp" EXIT
+
+startBuildkitd() {
+    addr=
+    helper=
+    if [ $(id -u) = 0 ]; then
+        addr=unix:///run/buildkit/buildkitd.sock
+    else
+        addr=unix://$XDG_RUNTIME_DIR/buildkit/buildkitd.sock
+        helper=$ROOTLESSKIT
+    fi
+    $helper $BUILDKITD $BUILDKITD_FLAGS --addr=$addr >$tmp/log 2>&1 &
+    pid=$!
+    echo $pid >$tmp/pid
+    echo $addr >$tmp/addr
+}
+
+waitForBuildkitd() {
+    addr=$(cat $tmp/addr)
+    try=0
+    max=$BUILDCTL_CONNECT_RETRIES_MAX
+    until $BUILDCTL --addr=$addr debug workers >/dev/null 2>&1; do
+        if [ $try -gt $max ]; then
+            echo >&2 "could not connect to $addr after $max trials"
+            echo >&2 "========== log =========="
+            cat >&2 $tmp/log
+            exit 1
+        fi
+        sleep $(awk "BEGIN{print (100 + $try * 20) * 0.001}")
+        try=$(expr $try + 1)
+    done
+}
+
+startBuildkitd
+waitForBuildkitd
+exec $BUILDCTL --addr=$(cat $tmp/addr) "$@"


### PR DESCRIPTION
This PR introduces a new example configuration for using `DIB` with `Kubernetes`.

### New Example Files for DIB with Kubernetes:

* **`examples/Dockerfile`:** Added a Dockerfile to build a custom Buildkit image, which uses the `moby/buildkit:master-rootless` base image and includes a `buildkitd-launcher` script.
* **`examples/buildkitd-launcher`:** Added a shell script to launch the Buildkit daemon (`buildkitd`) in a rootless environment, with support for dynamic configuration and retries for connection setup.

### Documentation:

* **`examples/README.md`:** Added a detailed guide explaining how to configure and use the DIB example, including instructions for building and pushing the custom Buildkit image, creating Kubernetes secrets, configuring the `.dib.yaml` file, and troubleshooting common issues.