### PR TITLE
fix: prevent image retagging with BuildKit backend && some refacto

### DIFF
--- a/pkg/buildkit/builder.go
+++ b/pkg/buildkit/builder.go
@@ -68,7 +68,7 @@ type Config struct {
 }
 
 // NewBuilder creates a new instance of Builder.
-func NewBKBuilder(cfg Config, workingDir string, binary string, localOnly bool) (*Builder, error) {
+func NewBKBuilder(cfg Config, shell executor.ShellExecutor, binary string, localOnly bool) (*Builder, error) {
 	var (
 		err             error
 		k8sExecutor     executor.KubernetesExecutor
@@ -77,7 +77,7 @@ func NewBKBuilder(cfg Config, workingDir string, binary string, localOnly bool) 
 	)
 
 	if localOnly {
-		shellExecutor = exec.NewShellExecutor(workingDir, nil)
+		shellExecutor = shell
 		contextProvider = NewLocalContextProvider()
 	} else {
 		k8sExecutor, err = createBuildkitKubernetesExecutor()

--- a/pkg/buildkit/builder_test.go
+++ b/pkg/buildkit/builder_test.go
@@ -125,7 +125,8 @@ func Test_NewBKBuilder(t *testing.T) {
 
 			t.Setenv("KUBECONFIG", kubeconfigPath)
 
-			builder, err := NewBKBuilder(tc.cfg, tc.workingDir, tc.binary, tc.localOnly)
+			shellExecutor := mock.NewShellExecutor(nil)
+			builder, err := NewBKBuilder(tc.cfg, shellExecutor, tc.binary, tc.localOnly)
 			if tc.expectedErr != nil {
 				require.Error(t, err)
 				assert.Contains(t, err.Error(), tc.expectedErr.Error())

--- a/pkg/buildkit/buildkitutil_test.go
+++ b/pkg/buildkit/buildkitutil_test.go
@@ -7,6 +7,7 @@ import (
 	"path/filepath"
 	"testing"
 
+	"github.com/radiofrance/dib/pkg/mock"
 	"github.com/radiofrance/dib/pkg/testutil"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -112,6 +113,136 @@ func TestBuildKitFile(t *testing.T) {
 				assert.Equal(t, defaultDockerfileName, file)
 				assert.NoError(t, err)
 			}
+		})
+	}
+}
+
+func TestGetBuildkitWorkerType(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name           string
+		buildctlBinary string
+		buildkitHost   string
+		mockOutput     string
+		mockError      error
+		expectedType   string
+		expectedError  bool
+		errorContains  string
+	}{
+		{
+			name:           "success with oci executor",
+			buildctlBinary: "buildctl",
+			buildkitHost:   "tcp://127.0.0.1:1234",
+			mockOutput:     `[{"labels":{"org.mobyproject.buildkit.worker.executor":"oci"}}]`,
+			mockError:      nil,
+			expectedType:   OciExecutorType,
+			expectedError:  false,
+		},
+		{
+			name:           "success with containerd executor",
+			buildctlBinary: "buildctl",
+			buildkitHost:   "tcp://127.0.0.1:1234",
+			mockOutput:     `[{"labels":{"org.mobyproject.buildkit.worker.executor":"containerd"}}]`,
+			mockError:      nil,
+			expectedType:   ContainerdExecutorType,
+			expectedError:  false,
+		},
+		{
+			name:           "execution error",
+			buildctlBinary: "buildctl",
+			buildkitHost:   "tcp://127.0.0.1:1234",
+			mockOutput:     "",
+			mockError:      fmt.Errorf("execution failed"),
+			expectedType:   "",
+			expectedError:  true,
+			errorContains:  "execution failed",
+		},
+		{
+			name:           "invalid JSON output",
+			buildctlBinary: "buildctl",
+			buildkitHost:   "tcp://127.0.0.1:1234",
+			mockOutput:     "invalid json",
+			mockError:      nil,
+			expectedType:   "",
+			expectedError:  true,
+			errorContains:  "failed to parse buildkit workers output",
+		},
+		{
+			name:           "no workers found",
+			buildctlBinary: "buildctl",
+			buildkitHost:   "tcp://127.0.0.1:1234",
+			mockOutput:     "[]",
+			mockError:      nil,
+			expectedType:   "",
+			expectedError:  true,
+			errorContains:  "no buildkit workers found",
+		},
+		{
+			name:           "missing labels",
+			buildctlBinary: "buildctl",
+			buildkitHost:   "tcp://127.0.0.1:1234",
+			mockOutput:     `[{"no_labels":true}]`,
+			mockError:      nil,
+			expectedType:   "",
+			expectedError:  true,
+			errorContains:  "worker labels not found or invalid format",
+		},
+		{
+			name:           "missing executor type",
+			buildctlBinary: "buildctl",
+			buildkitHost:   "tcp://127.0.0.1:1234",
+			mockOutput:     `[{"labels":{}}]`,
+			mockError:      nil,
+			expectedType:   "",
+			expectedError:  true,
+			errorContains:  "executor type not found or invalid format",
+		},
+		{
+			name:           "unknown executor type",
+			buildctlBinary: "buildctl",
+			buildkitHost:   "tcp://127.0.0.1:1234",
+			mockOutput:     `[{"labels":{"org.mobyproject.buildkit.worker.executor":"unknown"}}]`,
+			mockError:      nil,
+			expectedType:   "",
+			expectedError:  true,
+			errorContains:  "unknown buildkit worker type: unknown",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			// Create a mock shell executor with the expected output and error
+			mockExecutor := mock.NewShellExecutor([]mock.ExecutorResult{
+				{
+					Output: tt.mockOutput,
+					Error:  tt.mockError,
+				},
+			})
+
+			// Call the function under test
+			workerType, err := GetBuildkitWorkerType(tt.buildctlBinary, tt.buildkitHost, mockExecutor)
+
+			// Verify the results
+			if tt.expectedError {
+				require.Error(t, err)
+				if tt.errorContains != "" {
+					assert.Contains(t, err.Error(), tt.errorContains)
+				}
+				assert.Empty(t, workerType)
+			} else {
+				require.NoError(t, err)
+				assert.Equal(t, tt.expectedType, workerType)
+			}
+
+			// Verify the command was executed correctly
+			require.Len(t, mockExecutor.Executed, 1)
+			assert.Equal(t, tt.buildctlBinary, mockExecutor.Executed[0].Command)
+
+			expectedArgs := append(buildctlBaseArgs(tt.buildkitHost), "debug", "workers", "--format={{json .}}")
+			assert.Equal(t, expectedArgs, mockExecutor.Executed[0].Args)
 		})
 	}
 }


### PR DESCRIPTION
This PR improves BuildKit integration, refactors shell executor handling, and adds dynamic detection of BuildKit worker types.


**BuildKit Enhancements:**
- Added `GetBuildkitWorkerType` to detect worker types (`oci` or `containerd`) using `buildctl`. Updated `doBuild()` to log warnings and skip retagging for unsupported worker types.


**Shell Executor Refactor:**
- `NewBKBuilder` now accepts a `ShellExecutor` as a parameter for better flexibility and testability. Replaced inline `ShellExecutor` creation with `exec.NewShellExecutor`.


**Unit Tests:**
- Added tests for `GetBuildkitWorkerType` to handle various scenarios (e.g., invalid JSON, missing labels).