### PR TITLE
fix: update ldflags to use correct package path for versioning

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -9,10 +9,10 @@ builds:
     # Default: '-s -w -X main.version={{.Version}} -X main.commit={{.Commit}} -X main.date={{.Date}} -X main.builtBy=goreleaser'
     ldflags:
       - -s -w
-      - -X main.version={{.Version}}
-      - -X main.commit={{.Commit}}
-      - -X main.date={{.CommitDate}}
-      - -X main.builtBy=goreleaser
+      - -X github.com/radiofrance/dib/cmd.version={{.Version}}
+      - -X github.com/radiofrance/dib/cmd.commit={{.Commit}}
+      - -X github.com/radiofrance/dib/cmd.date={{.CommitDate}}
+      - -X github.com/radiofrance/dib/cmd.builtBy=goreleaser
     mod_timestamp: '{{ .CommitTimestamp }}'
     env:
       - CGO_ENABLED=0


### PR DESCRIPTION
fix regression due to https://github.com/radiofrance/dib/pull/731

````
faheddorgaa@MacBook-Pro-de-fahed:~/go/src/github.com/radiofrance/dib$ ./dist/dib_darwin_amd64_v1/dib version
14:23:31  WARN   Config File ".dib" Not Found in "[/Users/faheddorgaa/.config /Users/faheddorgaa/go/src/github.com/radiofrance/dib]"
version: v0.24.1-dev
build on darwin/amd64 by goreleaser at 2025-05-14T09:28:06Z with go1.24.3 (from commit f47eede11e3e09702883abc85ca98b6dc1d06f69)
````