### PR TITLE
deprecate: Docker and Kaniko backends

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ with one another, in a single command.
 - **Incremental Builds:** Images are only built when something has changed since the last build, saving time and resources.
 - **Dependency Resolution:** Supports dependencies between images. Builds will be queued until all parent images are built, ensuring a smooth and efficient build process.
 - **Test Suites:** Run test suites on images and ensure the tests pass before promoting images to production.
-- **Build Backends:** Multiple build backends supported, including Docker/BuildKit and Kaniko. Choose the backend that best suits your needs.
+- **Build Backends:** BuildKit is the recommended and default backend. Docker and Kaniko backends are deprecated and will be removed in a future release.
 - **Execution Environments:** dib supports multiple executors, allowing you to build images using different environments such as Shell, Docker, or Kubernetes.
 
 ## Documentation

--- a/cmd/build.go
+++ b/cmd/build.go
@@ -80,7 +80,8 @@ Otherwise, dib will create a new tag based on the previous tag.`
 	cmd.Flags().Bool("push", false,
 		"Push the images to the registry after building them.")
 	cmd.Flags().StringP("backend", "b", types.BuildKitBackend,
-		fmt.Sprintf("Build Backend used to run image builds. Supported backends: %v (docker and kaniko are deprecated)", supportedBackends))
+		fmt.Sprintf("Build Backend used to run image builds. Supported backends: %v "+
+			"(docker and kaniko are deprecated)", supportedBackends))
 	cmd.Flags().Int("rate-limit", 1,
 		"Concurrent number of builds that can run simultaneously")
 	cmd.Flags().StringArray("build-arg", []string{},
@@ -137,10 +138,13 @@ func buildAction(cmd *cobra.Command, _ []string) error {
 }
 
 func doBuild(opts dib.BuildOpts, buildArgs map[string]string) error {
-	if opts.Backend == types.BackendDocker {
-		logger.Warnf("The docker backend is deprecated and will be removed in a future release. Please use the buildkit backend instead.")
-	} else if opts.Backend == types.BackendKaniko {
-		logger.Warnf("The kaniko backend is deprecated and will be removed in a future release. Please use the buildkit backend instead.")
+	switch opts.Backend {
+	case types.BackendDocker:
+		logger.Warnf("The docker backend is deprecated and will be removed in a future release. " +
+			"Please use the buildkit backend instead.")
+	case types.BackendKaniko:
+		logger.Warnf("The kaniko backend is deprecated and will be removed in a future release. " +
+			"Please use the buildkit backend instead.")
 		if opts.LocalOnly {
 			logger.Warnf("Using Backend \"kaniko\" with the --local-only flag is partially supported.")
 		}

--- a/cmd/build.go
+++ b/cmd/build.go
@@ -79,8 +79,8 @@ Otherwise, dib will create a new tag based on the previous tag.`
 		"Build Docker images locally. If this flag is not set, the build will be performed in Kubernetes.")
 	cmd.Flags().Bool("push", false,
 		"Push the images to the registry after building them.")
-	cmd.Flags().StringP("backend", "b", types.BackendDocker,
-		fmt.Sprintf("Build Backend used to run image builds. Supported backends: %v", supportedBackends))
+	cmd.Flags().StringP("backend", "b", types.BuildKitBackend,
+		fmt.Sprintf("Build Backend used to run image builds. Supported backends: %v (docker and kaniko are deprecated)", supportedBackends))
 	cmd.Flags().Int("rate-limit", 1,
 		"Concurrent number of builds that can run simultaneously")
 	cmd.Flags().StringArray("build-arg", []string{},
@@ -137,8 +137,13 @@ func buildAction(cmd *cobra.Command, _ []string) error {
 }
 
 func doBuild(opts dib.BuildOpts, buildArgs map[string]string) error {
-	if opts.Backend == types.BackendKaniko && opts.LocalOnly {
-		logger.Warnf("Using Backend \"kaniko\" with the --local-only flag is partially supported.")
+	if opts.Backend == types.BackendDocker {
+		logger.Warnf("The docker backend is deprecated and will be removed in a future release. Please use the buildkit backend instead.")
+	} else if opts.Backend == types.BackendKaniko {
+		logger.Warnf("The kaniko backend is deprecated and will be removed in a future release. Please use the buildkit backend instead.")
+		if opts.LocalOnly {
+			logger.Warnf("Using Backend \"kaniko\" with the --local-only flag is partially supported.")
+		}
 	}
 
 	checkRequirements(opts)

--- a/docs/backends.md
+++ b/docs/backends.md
@@ -5,7 +5,7 @@ The build backend is a software or service responsible for actually building the
 building images, it delegates this part to the build backend.
 
 dib supports multiple build backends. Currently, available backends are `docker`, `kaniko`, and `buildkit`. You can select the 
-backend to use with the `--backend` option.
+backend to use with the `--backend` option. Note that `docker` and `kaniko` backends are deprecated and will be removed in a future release. `buildkit` is now the recommended and default backend.
 
 **Executor compatibility matrix**
 
@@ -16,6 +16,8 @@ backend to use with the `--backend` option.
 | BuildKit | ✔     | ✗      | ✔          |
 
 ## Docker
+
+> **Deprecated:** The Docker backend is deprecated and will be removed in a future release. Please use the BuildKit backend instead.
 
 The `docker` backend uses [Docker](https://www.docker.com/) behind the scenes, and runs `docker build` You need to have 
 the Docker CLI installed locally to use this backend.
@@ -40,6 +42,8 @@ If available, dib will try to use the BuildKit engine to build images, which is 
 build engine.
 
 ## Kaniko
+
+> **Deprecated:** The Kaniko backend is deprecated and will be removed in a future release. Please use the BuildKit backend instead.
 
 [Kaniko](https://github.com/GoogleContainerTools/kaniko) offers a way to build container images inside a container 
 or Kubernetes cluster, without the security tradeoff of running a docker daemon container with host privileges.

--- a/docs/examples/config/reference.yaml
+++ b/docs/examples/config/reference.yaml
@@ -31,7 +31,7 @@ reports_dir: reports
 #
 # Note: "docker" and "kaniko" backends are deprecated and will be removed in a future release.
 # The "buildkit" backend is now the recommended and default backend.
-# 
+#
 # Note: the kaniko backend must be run in a containerized environment such as Docker or Kubernetes.
 # See the "executor" section below.
 backend: buildkit

--- a/docs/examples/config/reference.yaml
+++ b/docs/examples/config/reference.yaml
@@ -27,13 +27,57 @@ build_arg:
 # Path to the directory where the reports are generated. The directory will be created if it doesn't exist.
 reports_dir: reports
 
-# The build backend. Can either be set to "docker" or "kaniko".
+# The build backend. Can be set to "buildkit" (recommended), "docker" (deprecated), or "kaniko" (deprecated).
 #
+# Note: "docker" and "kaniko" backends are deprecated and will be removed in a future release.
+# The "buildkit" backend is now the recommended and default backend.
+# 
 # Note: the kaniko backend must be run in a containerized environment such as Docker or Kubernetes.
 # See the "executor" section below.
-backend: docker
+backend: buildkit
 
-# Kaniko settings. Required only if using the Kaniko build backend.
+# BuildKit settings. Required when using the BuildKit backend.
+buildkit:
+  # The build context directory has to be uploaded somewhere in order for the BuildKit pod to retrieve it,
+  # when using remote executor (Kubernetes). Currently, only AWS S3 is supported.
+  context:
+    # Store the build context in an AWS S3 bucket.
+    s3:
+      bucket: my-bucket
+      region: eu-west-3
+  # Executor configuration for Kubernetes.
+  executor:
+    # Configuration for the "kubernetes" executor.
+    kubernetes:
+      namespace: buildkit
+      image: moby/buildkit:latest
+      # References a secret containing the Docker configuration file used to authenticate to the registry.
+      docker_config_secret: docker-config-prod
+      env_secrets:
+        # Additional Secret mounted as environment variables.
+        # Used for instance to download the build context from AWS S3.
+        - aws-s3-secret
+      container_override: |
+        resources:
+          limits:
+            cpu: 2
+            memory: 8Gi
+          requests:
+            cpu: 1
+            memory: 2Gi
+      pod_template_override: |
+        spec:
+          affinity:
+            nodeAffinity:
+              requiredDuringSchedulingIgnoredDuringExecution:
+                nodeSelectorTerms:
+                - matchExpressions:
+                  - key: kops.k8s.io/instancegroup
+                    operator: In
+                    values:
+                    - spot-instances
+
+# Kaniko settings. Required only if using the Kaniko build backend (deprecated).
 kaniko:
   # The build context directory has to be uploaded somewhere in order for the Kaniko pod to retrieve it,
   # when using remote executor (Kuberentes or remote docker host). Currently, only AWS S3 is supported.

--- a/docs/executors.md
+++ b/docs/executors.md
@@ -7,11 +7,11 @@ of operation (build, test), and the executors configured in the configuration fi
 
 **Build backend compatibility matrix**
 
-| Executor   | Docker | Kaniko |
-|------------|--------|--------|
-| Local      | ✔      | ✗      |
-| Docker     | ✗      | ✔      |
-| Kubernetes | ✗      | ✔      |
+| Executor   | BuildKit (recommended) | Docker (deprecated) | Kaniko (deprecated) |
+|------------|------------------------|---------------------|---------------------|
+| Local      | ✔                      | ✔                   | ✗                   |
+| Docker     | ✗                      | ✗                   | ✔                   |
+| Kubernetes | ✔                      | ✗                   | ✔                   |
 
 ## Local
 


### PR DESCRIPTION
 mark Docker and Kaniko backends as deprecated in documentation and code