### PR TITLE
rename: [docker images builder] -> [DAG image builder]

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-dib: Docker Image Builder
+dib: DAG Image Builder
 =========================
 
 ![GitHub release (latest SemVer)](https://img.shields.io/github/v/release/radiofrance/dib?sort=semver)

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -32,8 +32,8 @@ var rootCmd = &cobra.Command{
 	CompletionOptions: cobra.CompletionOptions{
 		HiddenDefaultCmd: true,
 	},
-	Short: "An Opinionated Docker Image Builder",
-	Long: `Docker Image Builder helps building a complex image dependency graph
+	Short: "An Opinionated DAG Image Builder",
+	Long: `DAG Image Builder helps building a complex image dependency graph
 
 Run dib --help for more information`,
 }

--- a/examples/README.md
+++ b/examples/README.md
@@ -1,4 +1,4 @@
-# DIB (Docker Image Builder) Example Configuration Guide
+# DIB (DAG Image Builder) Example Configuration Guide
 
 This guide explains how to configure and use the DIB example for building and pushing Docker images using Kubernetes.
 


### PR DESCRIPTION
update references from Docker Image Builder to DAG Image Builder in documentation