### PR TITLE
feat: enable silent usage for CLI commands

### DIFF
--- a/cmd/build.go
+++ b/cmd/build.go
@@ -46,10 +46,11 @@ Otherwise, dib will create a new tag based on the previous tag.`
 		longHelp += "WARNING: `dib build` is not supported on Windows yet."
 	}
 	cmd := &cobra.Command{
-		Use:   "build",
-		Short: "Run oci images builds",
-		Long:  longHelp,
-		RunE:  buildAction,
+		Use:          "build",
+		Short:        "Run oci images builds",
+		Long:         longHelp,
+		RunE:         buildAction,
+		SilenceUsage: true,
 	}
 	cmd.Flags().String("buildkit-host", "",
 		"buildkit host address.")

--- a/cmd/docgen.go
+++ b/cmd/docgen.go
@@ -20,10 +20,11 @@ var cmdDocPath string
 
 func docgenCommand() *cobra.Command {
 	cmd := &cobra.Command{
-		Use:    "docgen",
-		Short:  "Generate the documentation for the CLI commands.",
-		Hidden: true,
-		RunE:   docgenAction,
+		Use:          "docgen",
+		Short:        "Generate the documentation for the CLI commands.",
+		Hidden:       true,
+		RunE:         docgenAction,
+		SilenceUsage: true,
 	}
 	cmd.Flags().StringVar(&cmdDocPath, "path", "./docs/cmd",
 		"path to write the generated documentation to")

--- a/cmd/list.go
+++ b/cmd/list.go
@@ -28,10 +28,11 @@ The output can be customized with the --output flag :
 `
 
 	cmd := &cobra.Command{
-		Use:   "list",
-		Short: "List all images managed by dib",
-		Long:  longHelp,
-		RunE:  listAction,
+		Use:          "list",
+		Short:        "List all images managed by dib",
+		Long:         longHelp,
+		RunE:         listAction,
+		SilenceUsage: true,
 	}
 	cmd.Flags().StringP("output", "o", dib.ConsoleFormat,
 		"Output format : console|graphviz|go-template-file")

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -36,6 +36,7 @@ var rootCmd = &cobra.Command{
 	Long: `DAG Image Builder helps building a complex image dependency graph
 
 Run dib --help for more information`,
+	SilenceUsage: true,
 }
 
 func Execute() {

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -36,7 +36,8 @@ var rootCmd = &cobra.Command{
 	Long: `DAG Image Builder helps building a complex image dependency graph
 
 Run dib --help for more information`,
-	SilenceUsage: true,
+	SilenceUsage:  true,
+	SilenceErrors: true,
 }
 
 func Execute() {


### PR DESCRIPTION
* Add the `SilenceUsage: true` flag to all command definitions.
 This flag prevents Cobra from automatically displaying the command's usage information when an error occurs, resulting in cleaner error output.
* Remove the duplicate error message produced by the program's logging module and Cobra's stderr.