### PR TITLE
fix: add SilenceErrors to cobra commands

### DIFF
--- a/cmd/build.go
+++ b/cmd/build.go
@@ -46,11 +46,12 @@ Otherwise, dib will create a new tag based on the previous tag.`
 		longHelp += "WARNING: `dib build` is not supported on Windows yet."
 	}
 	cmd := &cobra.Command{
-		Use:          "build",
-		Short:        "Run oci images builds",
-		Long:         longHelp,
-		RunE:         buildAction,
-		SilenceUsage: true,
+		Use:           "build",
+		Short:         "Run oci images builds",
+		Long:          longHelp,
+		RunE:          buildAction,
+		SilenceUsage:  true,
+		SilenceErrors: true,
 	}
 	cmd.Flags().String("buildkit-host", "",
 		"buildkit host address.")

--- a/cmd/docgen.go
+++ b/cmd/docgen.go
@@ -20,11 +20,12 @@ var cmdDocPath string
 
 func docgenCommand() *cobra.Command {
 	cmd := &cobra.Command{
-		Use:          "docgen",
-		Short:        "Generate the documentation for the CLI commands.",
-		Hidden:       true,
-		RunE:         docgenAction,
-		SilenceUsage: true,
+		Use:           "docgen",
+		Short:         "Generate the documentation for the CLI commands.",
+		Hidden:        true,
+		RunE:          docgenAction,
+		SilenceUsage:  true,
+		SilenceErrors: true,
 	}
 	cmd.Flags().StringVar(&cmdDocPath, "path", "./docs/cmd",
 		"path to write the generated documentation to")

--- a/cmd/list.go
+++ b/cmd/list.go
@@ -28,11 +28,12 @@ The output can be customized with the --output flag :
 `
 
 	cmd := &cobra.Command{
-		Use:          "list",
-		Short:        "List all images managed by dib",
-		Long:         longHelp,
-		RunE:         listAction,
-		SilenceUsage: true,
+		Use:           "list",
+		Short:         "List all images managed by dib",
+		Long:          longHelp,
+		RunE:          listAction,
+		SilenceUsage:  true,
+		SilenceErrors: true,
 	}
 	cmd.Flags().StringP("output", "o", dib.ConsoleFormat,
 		"Output format : console|graphviz|go-template-file")


### PR DESCRIPTION
- Added SilenceErrors: true to build, docgen, and list commands
- This prevents cobra from printing errors to stderr when RunE returns an error
- Improves error handling consistency across CLI commands

Closes #791 