### PR TITLE
Fix buildkit labels

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -135,7 +135,6 @@ func preInitLogLevelFromFlags() {
 	if rootCmd == nil {
 		return
 	}
-
 	flag := rootCmd.PersistentFlags().Lookup("log-level")
 	if flag != nil && flag.Changed {
 		if val, err := rootCmd.PersistentFlags().GetString("log-level"); err == nil {
@@ -143,7 +142,6 @@ func preInitLogLevelFromFlags() {
 			return
 		}
 	}
-
 	if val, ok := os.LookupEnv("DIB_LOG_LEVEL"); ok && val != "" {
 		logger.SetLevel(&val)
 	}

--- a/pkg/buildkit/builder.go
+++ b/pkg/buildkit/builder.go
@@ -262,8 +262,8 @@ func generateBuildctlArgs(opts types.ImageBuilderOpts) ([]string, error) {
 		buildctlArgs = append(buildctlArgs, "--opt=build-arg:"+key+"="+val)
 	}
 
-	for _, l := range opts.Labels {
-		buildctlArgs = append(buildctlArgs, "--opt=label="+l)
+	for k, v := range opts.Labels {
+		buildctlArgs = append(buildctlArgs, "--opt=label:"+k+"="+v)
 	}
 
 	return buildctlArgs, nil

--- a/pkg/buildkit/builder_test.go
+++ b/pkg/buildkit/builder_test.go
@@ -308,7 +308,7 @@ func Test_Build_Local(t *testing.T) {
 					fmt.Sprintf("--local=dockerfile=%s", context),
 					"--opt=filename=Dockerfile",
 					"--opt=build-arg:someArg=someValue",
-					"--opt=label=someValue",
+					"--opt=label:someLabel=someValue",
 				}
 			},
 			expectedError: nil,
@@ -330,7 +330,7 @@ func Test_Build_Local(t *testing.T) {
 					fmt.Sprintf("--local=dockerfile=%s", context),
 					"--opt=filename=Dockerfile",
 					"--opt=build-arg:someArg=someValue",
-					"--opt=label=someValue",
+					"--opt=label:someLabel=someValue",
 				}
 			},
 			expectedError: nil,
@@ -352,7 +352,7 @@ func Test_Build_Local(t *testing.T) {
 					fmt.Sprintf("--local=dockerfile=%s", context),
 					"--opt=filename=Dockerfile",
 					"--opt=build-arg:someArg=someValue",
-					"--opt=label=someValue",
+					"--opt=label:someLabel=someValue",
 				}
 			},
 			expectedError: nil,
@@ -374,7 +374,7 @@ func Test_Build_Local(t *testing.T) {
 					fmt.Sprintf("--local=dockerfile=%s", context),
 					"--opt=filename=Dockerfile",
 					"--opt=build-arg:someArg=someValue",
-					"--opt=label=someValue",
+					"--opt=label:someLabel=someValue",
 				}
 			},
 			expectedError: nil,
@@ -396,7 +396,7 @@ func Test_Build_Local(t *testing.T) {
 					fmt.Sprintf("--local=dockerfile=%s", context),
 					"--opt=filename=Dockerfile",
 					"--opt=build-arg:someArg=someValue",
-					"--opt=label=someValue",
+					"--opt=label:someLabel=someValue",
 					fmt.Sprintf("--opt=target=%s", "prod"),
 				}
 			},


### PR DESCRIPTION
```
faheddorgaa@lima-buildkit:/Users/faheddorgaa/go/src/github.com/radiofrance/dib/dist$ ctr --address /run/user/501/containerd/containerd.sock i inspect --content  europe-west9-docker.pkg.dev/radio-france-dev/registry-test/lorem:dev-gee-mississippi-berlin-coffee
europe-west9-docker.pkg.dev/radio-france-dev/registry-test/lorem:dev-gee-mississippi-berlin-coffee
│    Created: 2025-10-02 16:02:06.763150698 +0000 UTC
│    Updated: 2025-10-02 16:05:36.013397227 +0000 UTC
└── application/vnd.docker.distribution.manifest.v2+json @sha256:fb96e9bef6b2283d3f6732948c8349924d988094cef44294e6ce75ff93dc568c (503 bytes)
    │   ┌────────Labels─────────
    │   │"containerd.io/gc.ref.content.0": "sha256:25978f4e5c71272757c942b8c1717e33c77438b6043b7f220151f96af26ba24d"
    │   │"containerd.io/gc.ref.content.1": "sha256:9824c27679d3b27c5e1cb00a73adb6f4f8d556994111c12db3c5d61a0c843df8"
    │   └───────────────────────
    │   ┌────────Content────────
    │   │{
    │   │   "schemaVersion": 2,
    │   │   "mediaType": "application/vnd.docker.distribution.manifest.v2+json",
    │   │   "config": {
    │   │      "mediaType": "application/vnd.docker.container.image.v1+json",
    │   │      "digest": "sha256:25978f4e5c71272757c942b8c1717e33c77438b6043b7f220151f96af26ba24d",
    │   │      "size": 1234
    │   │   },
    │   │   "layers": [
    │   │      {
    │   │         "mediaType": "application/vnd.docker.image.rootfs.diff.tar.gzip",
    │   │         "digest": "sha256:9824c27679d3b27c5e1cb00a73adb6f4f8d556994111c12db3c5d61a0c843df8",
    │   │         "size": 3799689
    │   │      }
    │   │   ]
    │   │}
    │   └───────────────────────
    ├── application/vnd.docker.container.image.v1+json @sha256:25978f4e5c71272757c942b8c1717e33c77438b6043b7f220151f96af26ba24d (1234 bytes)
    │   ┌────────Labels─────────
    │   │"containerd.io/gc.ref.snapshot.overlayfs": "sha256:418dccb7d85a63a6aa574439840f7a6fa6fd2321b3e2394568a317735e867d35"
    │   └───────────────────────
    │   ┌────────Content────────
    │   │{
    │   │   "architecture": "amd64",
    │   │   "config": {
    │   │      "Env": [
    │   │         "PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin"
    │   │      ],
    │   │      "Cmd": [
    │   │         "/bin/sh"
    │   │      ],
    │   │      "WorkingDir": "/",
    │   │      "Labels": {
    │   │         "name": "lorem",
    │   │         "org.opencontainers.image.base.name": "docker.io/alpine",
    │   │         "org.opencontainers.image.created": "2025-10-02T18:05:35+02:00",
    │   │         "org.opencontainers.image.ref.name": "gee-mississippi-berlin-coffee",
    │   │         "org.opencontainers.image.revision": "51cf18b7f9624d52a7c217c1bdcc5b5f9853ab5f",
    │   │         "org.opencontainers.image.source": "/dist/docker/Dockerfile",
    │   │         "org.opencontainers.image.title": "lorem",
    │   │         "org.opencontainers.image.url": "/dist/docker/Dockerfile",
    │   │         "org.opencontainers.image.version": "gee-mississippi-berlin-coffee"
    │   │      }
    │   │   },
    │   │   "created": "2025-07-15T11:01:16Z",
    │   │   "history": [
    │   │      {
    │   │         "created": "2025-07-15T11:01:16Z",
    │   │         "created_by": "ADD alpine-minirootfs-3.22.1-x86_64.tar.gz / # buildkit",
    │   │         "comment": "buildkit.dockerfile.v0"
    │   │      },
    │   │      {
    │   │         "created": "2025-07-15T11:01:16Z",
    │   │         "created_by": "CMD [\"/bin/sh\"]",
    │   │         "comment": "buildkit.dockerfile.v0",
    │   │         "empty_layer": true
    │   │      },
    │   │      {
    │   │         "created": "2025-07-15T11:01:16Z",
    │   │         "created_by": "LABEL name=lorem",
    │   │         "comment": "buildkit.dockerfile.v0",
    │   │         "empty_layer": true
    │   │      }
    │   │   ],
    │   │   "os": "linux",
    │   │   "rootfs": {
    │   │      "type": "layers",
    │   │      "diff_ids": [
    │   │         "sha256:418dccb7d85a63a6aa574439840f7a6fa6fd2321b3e2394568a317735e867d35"
    │   │      ]
    │   │   }
    │   │}
    │   └───────────────────────
    └── application/vnd.docker.image.rootfs.diff.tar.gzip @sha256:9824c27679d3b27c5e1cb00a73adb6f4f8d556994111c12db3c5d61a0c843df8 (3799689 bytes)
```