### PR TITLE
fix(CI): create codecov.yml allowing up to 0.1% coverage variance

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -1,0 +1,5 @@
+coverage:
+  status:
+    patch:
+      default:
+        threshold: 0.1%


### PR DESCRIPTION
We have some non-deterministic tests that are creating different coverage results.
For example in this PR: https://github.com/radiofrance/dib/pull/888

<img width="1637" height="626" alt="Screenshot 2026-02-03 at 17 48 20" src="https://github.com/user-attachments/assets/80cb2e10-f1a6-4bfe-8e68-137d3feb6232" />

The 0.1% threshold would allow a few lines to transition from covered to uncovered, without reporting a negative patch coverage result.

I got inspired by : https://docs.codecov.com/docs/unexpected-coverage-changes