### PR TITLE
fix(report): replace / with _ in when reading report files

### DIFF
--- a/pkg/report/template.go
+++ b/pkg/report/template.go
@@ -6,6 +6,7 @@ import (
 	"io/fs"
 	"os"
 	"path"
+	"strings"
 	"time"
 
 	"github.com/radiofrance/dib/pkg/dag"
@@ -167,7 +168,7 @@ func parseBuildLogs(dibReport *Report) map[string]string {
 			continue
 		}
 
-		rawImageBuildLogs, err := os.ReadFile(path.Join(dibReport.GetBuildReportDir(), buildReport.Image.ShortName) + ".txt")
+		rawImageBuildLogs, err := os.ReadFile(path.Join(dibReport.GetBuildReportDir(), strings.ReplaceAll(buildReport.Image.ShortName, "/", "_")) + ".txt") //nolint:lll
 		if err != nil {
 			buildLogsData[buildReport.Image.ShortName] = err.Error()
 			continue
@@ -190,7 +191,7 @@ func parseGossLogs(dibReport *Report) map[string]any {
 			continue
 		}
 
-		gossTestLogsFile := fmt.Sprintf("%s/junit-%s.xml", dibReport.GetJunitReportDir(), buildReport.Image.ShortName)
+		gossTestLogsFile := fmt.Sprintf("%s/junit-%s.xml", dibReport.GetJunitReportDir(), strings.ReplaceAll(buildReport.Image.ShortName, "/", "_")) //nolint:lll
 
 		rawGossTestLogs, err := os.ReadFile(gossTestLogsFile) //nolint:gosec
 		if err != nil {


### PR DESCRIPTION
This pull request updates how image short names containing slashes are handled when reading build and test log files. The main improvement is to replace any `/` characters in image short names with underscores, ensuring that generated file paths are valid and follows the same paths as the ones used during report generation.

**File path handling improvements:**

* Updated `parseBuildLogs` in `pkg/report/template.go` to replace `/` with `_` in `buildReport.Image.ShortName` when constructing the log file path, preventing invalid file names.
* Updated `parseGossLogs` in `pkg/report/template.go` to similarly replace `/` with `_` in `buildReport.Image.ShortName` when constructing the JUnit XML file path.