### PR TITLE
fix(ci): add threshold to codecov project status to reduce flakiness

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -1,5 +1,9 @@
 coverage:
   status:
+    project:
+      default:
+        target: auto
+        threshold: 1%
     patch:
       default:
         threshold: 0.1%


### PR DESCRIPTION
Adds a threshold: 1% to the codecov/project status check (previously undefined).

codecov/project was failing on PRs with negligible, unrelated coverage swings (e.g. #953 failed on a -0.09% diff from a dependency digest bump). Only patch had a threshold configured; project had none, so any drop at all failed the check.

codecov/project now only fails if project coverage drops by more than 1 percentage point vs. main.
codecov/patch behavior is unchanged (still 0.1% threshold).

Note: this only takes effect for PRs opened after this is merged to main, since Codecov reads codecov.yml from the base branch.