### PR TITLE
fix: make quotes optional around LABEL values

### DIFF
--- a/pkg/dockerfile/dockerfile.go
+++ b/pkg/dockerfile/dockerfile.go
@@ -15,7 +15,7 @@ const dockerfileName = "Dockerfile"
 
 var (
 	rxFrom  = regexp.MustCompile(`^FROM\s+(?P<ref>(?P<image>[^:@\s]+):?(?P<tag>[^\s@]+)?@?(?P<digest>sha256:[^\s]+)?)`) //nolint:lll
-	rxLabel = regexp.MustCompile(`^LABEL\s+(\S+)="(\S+)"`)
+	rxLabel = regexp.MustCompile(`^LABEL\s+(\S+)=(?:"([^"]*)"|(\S+))`)
 	rxArg   = regexp.MustCompile(`^ARG\s+([a-zA-Z_]\w*)(\s*=\s*[^#\n]*)?`)
 )
 
@@ -94,7 +94,8 @@ func ParseDockerfile(filename string) (*Dockerfile, error) {
 			})
 		case rxLabel.MatchString(txt):
 			result := rxLabel.FindStringSubmatch(txt)
-			dckFile.addLabel(result[1], result[2])
+			// Quotes around the value are optional, only one of both groups is filled.
+			dckFile.addLabel(result[1], result[2]+result[3])
 		case rxArg.MatchString(txt):
 			result := rxArg.FindStringSubmatch(txt)
 			dckFile.addArg(result[1], txt)

--- a/pkg/dockerfile/dockerfile_test.go
+++ b/pkg/dockerfile/dockerfile_test.go
@@ -213,6 +213,22 @@ func TestParseDockerfile(t *testing.T) {
 			},
 			expectedArgs: map[string]string{},
 		},
+		"dockerfile with an unquoted label": {
+			filename: "labels.dockerfile",
+			expectedFrom: []dockerfile.ImageRef{
+				{
+					Name:   "registry.com/example",
+					Tag:    "",
+					Digest: "",
+				},
+			},
+			expectedLabels: map[string]string{
+				"name":           "example",
+				"skipbuild":      "true",
+				"dib.extra-tags": "v1,v2",
+			},
+			expectedArgs: map[string]string{},
+		},
 	}
 	for name, test := range tests {
 		t.Run(name, func(t *testing.T) {

--- a/test/fixtures/dockerfile/labels.dockerfile
+++ b/test/fixtures/dockerfile/labels.dockerfile
@@ -1,0 +1,4 @@
+FROM registry.com/example
+LABEL name="example"
+LABEL skipbuild=true
+LABEL dib.extra-tags="v1,v2"


### PR DESCRIPTION
`LABEL dib.extra-tags=v0.19.1` sans guillemets est ignoré en silence : dib build et push l'image sans son tag, aucun warning.

C'est déjà arrivé sur referentiel-version ([0d6b6013](https://gitlab.dnm.radiofrance.fr/struktur/referentiel-version/-/commit/0d6b6013f536158457bbb962c266f3d8d6ec4dcd), corrigé 10 min plus tard par un commit appelé "fix label, add quotes"). Les guillemets sont optionnels dans un Dockerfile, autant que dib accepte les deux formes.